### PR TITLE
test(grading): parity gate 3 lanes + opt-in defaults lock (#1360)

### DIFF
--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -747,12 +747,32 @@ s3 = S3BundleStore(bucket="tolokaforge-bundles", prefix="grade_bundles")
 
 ## Parity gate
 
-The `runner_rpc` and `grader_rpc` legs must produce byte-identical
-`Grade` output for every combination of grading components a task
-declares — except the two accepted, documented divergences (KB
-passthrough for the judge; hash grading refused). A canonical parity
-gate at `tests/canonical/test_grader_parity_reference.py` locks that
-invariant against a growing corpus of reference packs.
+The parity gate covers three substrate topologies over the same
+10-pack corpus:
+
+- **Lane A** — `runner_rpc` (`InProcessGradingSubstrate` inside the
+  runner) vs `grader_rpc` (`LiveRunnerCallbackGradingSubstrate` dialling
+  the runner's `SubstrateService` gRPC). Both wire `Grade` messages
+  byte-match the committed baseline.
+- **Lane B** — `grader_rpc + snapshot=on`
+  (`SnapshotGradingSubstrate` over a produced grade bundle). Byte-parity
+  against the same baseline for the eight snapshot-gradable packs;
+  `state_checks_db_probes_only` surfaces `SubstrateUnreachableError`
+  in the Grade's `reasons` text (the state-check backend catches per
+  probe), and `hash_and_all_four` raises `GradingFailedError` with the
+  same hash-refusal fragment Lane A pins.
+- **Lane C** — three sequential in-process replays against the same
+  frozen bundle bytes produce byte-identical `Grade` output. The
+  regrade-parity property.
+
+Together the three lanes lock: (1) the two shipped substrate topologies
+produce byte-identical Grades; (2) the offline replay substrate reads
+the same story off a bundle; (3) regrade is deterministic across
+sequential dispatches. Except the two accepted, documented divergences
+(KB passthrough for the judge; hash grading refused), every combination
+of grading components a task declares grades identically. The canonical
+gate at `tests/canonical/test_grader_parity_reference.py` locks all
+three lanes against a growing corpus of reference packs.
 
 **Harness.** `tests/utils/grader_parity_harness.py` boots an in-process
 `RunnerServiceImpl` + `SubstrateServicer` and drives each leg against

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -431,6 +431,12 @@ truthy, registers `add_SubstrateServiceServicer_to_server` on the same
 started with the flag off returns `UNIMPLEMENTED` for any
 `SubstrateService/*` call.
 
+The three opt-in defaults that keep snapshot mode off out of the box —
+`GraderConfig.expose_substrate=False`, `GraderConfig.snapshot=None`, and
+`SnapshotBundleConfig.enabled=False` — are locked mechanically by
+`tests/canonical/test_grader_defaults.py`. A PR flipping any of the
+three fails that canonical test unless it also edits the lock file.
+
 The eight RPCs:
 
 | RPC | What it returns |

--- a/docs/GRADE_BUNDLE.md
+++ b/docs/GRADE_BUNDLE.md
@@ -84,6 +84,8 @@ Because parts' digests live inside the manifest, changing any part changes its m
 
 The manifest itself does NOT contain its own name (that would be recursive). Consumers compute the name over the manifest bytes on read.
 
+Regrade parity across replays — three sequential in-process `SnapshotGradingSubstrate` dispatches against the same bundle bytes produce byte-identical `Grade` output — is locked by `test_regrade_parity_snapshot_replays` in the canonical parity gate.
+
 ## Schema-version compatibility
 
 Readers refuse unknown MAJOR versions and accept unknown MINOR versions.

--- a/tests/README.md
+++ b/tests/README.md
@@ -250,14 +250,27 @@ Compare output against committed golden snapshots in `snapshots/`.
   last assistant turn, while `build_turn_timeline` takes the calls per turn — which
   is what an ordering or turn-window property needs.
 - Grader parity reference (`test_grader_parity_reference.py`) — the ten packs under
-  `tests/canonical/grader_parity_baselines/` are graded through both the in-process
-  substrate leg and the composite dispatch that speaks the standalone grader's gRPC,
-  and both wire `Grade` messages must byte-match the committed
-  `expected_grade.json` under the shared `serialise_grade` projection. A failure
-  means the two grader shapes have drifted; the `hash_and_all_four` pack additionally
-  pins the composite dispatch's refusal message against the ADR-0040 fragment. The
-  isolation invariant — one non-trivial grading block per isolation pack — is locked
-  by `test_isolation_pack_config_is_single_seam`, so a divergence at one seam
+  `tests/canonical/grader_parity_baselines/` are driven through three substrate
+  topologies, each locking one property against the shared `serialise_grade`
+  projection over the committed `expected_grade.json`:
+  - **Lane A** — `run_via_runner_rpc` (the runner's in-process `InProcessGradingSubstrate`)
+    vs `run_via_grader_rpc` (the standalone grader's `LiveRunnerCallbackGradingSubstrate`
+    dialling the runner's `SubstrateService` gRPC). Both wire `Grade` messages
+    byte-match the baseline.
+  - **Lane B** — `run_via_snapshot_rpc` (the standalone grader's composite over a
+    `SnapshotGradingSubstrate` reading a per-test-run bundle produced from the
+    same substrate the runner leg reads). Byte-parity against the same baseline
+    for the eight snapshot-gradable packs; `state_checks_db_probes_only` surfaces
+    `SubstrateUnreachableError` in the Grade's ``reasons`` text (the state-check
+    backend catches per-probe, matching the fail-loud db-probe contract);
+    `hash_and_all_four` raises `GradingFailedError` on the grader-side hash-refusal
+    branch, matching Lane A's fragment.
+  - **Lane C** — three sequential in-process replays against the same frozen
+    bundle bytes produce byte-identical Grades — the regrade-parity property.
+  A failure means the two grader shapes have drifted or the substrate topology
+  no longer produces a deterministic Grade. The isolation invariant — one
+  non-trivial grading block per isolation pack — is locked by
+  `test_isolation_pack_config_is_single_seam`, so a divergence at one seam
   surfaces at exactly one pack. The RC-smoke sibling
   (`tests/integration/deploy/test_rc_smoke_parity_reference.py`) reads the SAME
   corpus over real containers — an import-time

--- a/tests/canonical/test_grader_defaults.py
+++ b/tests/canonical/test_grader_defaults.py
@@ -1,0 +1,38 @@
+"""Mechanical guardrail on the two load-bearing snapshot-mode opt-in defaults.
+
+Locks that a PR flipping ``SnapshotBundleConfig.enabled`` or
+``GraderConfig.expose_substrate`` (or making ``GraderConfig.snapshot``
+present by default) must also edit this file. Both defaults are
+security-relevant: ``expose_substrate=true`` opens the runner's
+:class:`SubstrateService` gRPC surface, and ``snapshot.enabled=true``
+turns on the orchestrator's grade-bundle producer seam. A brownfield
+deploy that accidentally opens either would surface here first, before
+the change reached a running system.
+
+Assertions read through :attr:`BaseModel.model_fields`, not through a
+fresh instance's :meth:`model_dump`, so a rename of the field or a
+Pydantic-v2 default-shape change surfaces at the exact assertion — the
+same seam the constants that write them live on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.models.run_config import GraderConfig, SnapshotBundleConfig
+
+pytestmark = pytest.mark.canonical
+
+
+def test_snapshot_bundle_config_disabled_by_default() -> None:
+    assert SnapshotBundleConfig.model_fields["enabled"].default is False
+    with pytest.raises(ValueError, match="requires grader.snapshot.store"):
+        SnapshotBundleConfig(enabled=True)
+
+
+def test_grader_config_expose_substrate_off_by_default() -> None:
+    assert GraderConfig.model_fields["expose_substrate"].default is False
+
+
+def test_grader_snapshot_defaults_to_none() -> None:
+    assert GraderConfig.model_fields["snapshot"].default is None

--- a/tests/canonical/test_grader_parity_reference.py
+++ b/tests/canonical/test_grader_parity_reference.py
@@ -22,8 +22,9 @@ baseline produces no diff.
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -31,12 +32,15 @@ from tests.utils.grader_parity_harness import (
     REFRESH_BASELINES_OPTION,
     ParityPack,
     assert_grader_rpc_refuses,
+    assert_snapshot_rpc_refuses,
     components_diff,
     load_parity_pack,
+    produce_snapshot_bundle,
     read_baseline,
     refresh_or_assert_baseline,
     run_via_grader_rpc,
     run_via_runner_rpc,
+    run_via_snapshot_rpc,
     serialise_grade,
     should_refresh_baselines,
     write_baseline,
@@ -49,34 +53,101 @@ pytestmark = pytest.mark.canonical
 
 _BASELINES_ROOT = Path(__file__).parent / "grader_parity_baselines"
 
+
+@dataclass(frozen=True)
+class ParityPackSpec:
+    """One row of the parity gate's pack matrix.
+
+    Fields:
+
+    * ``name`` — the pack directory name under
+      ``tests/canonical/grader_parity_baselines/``.
+    * ``snapshot_kind`` — how Lane B (snapshot dispatch) and Lane C
+      (regrade replays) treat the pack:
+
+      - ``"gradable"`` — the snapshot substrate can serve every read the
+        pack's config declares; the leg asserts byte-parity against the
+        pack's committed :file:`expected_grade.json`.
+      - ``"refusal"`` — the snapshot substrate refuses a read the pack
+        declares (``state_checks.db_probes`` offline) or the grader-side
+        composite refuses before any substrate read
+        (``state_checks.hash_enabled`` on ``hash_and_all_four``); the
+        leg asserts :class:`GradingFailedError` with the pack's declared
+        message fragment instead.
+
+    * ``expected_block`` — the isolation-invariant seam
+      ``test_isolation_pack_config_is_single_seam`` locks. Applies to
+      isolation packs only; ``None`` for composite packs, where the
+      invariant is "≥2 populated seams" and the single-seam parametrise
+      does not read the field.
+    """
+
+    name: str
+    snapshot_kind: Literal["gradable", "refusal"]
+    expected_block: str | None = None
+
+
 # One row per plug-in seam. Each pack's grading.yaml declares exactly
 # one non-trivial grading block — the isolation invariant
 # ``test_isolation_pack_config_is_single_seam`` locks — so a divergence at
 # that seam surfaces at that pack alone.
-_ISOLATION_PACKS: list[tuple[str, str]] = [
-    ("state_checks_jsonpath_only", "state_checks"),
-    ("state_checks_db_probes_only", "state_checks"),
-    ("transcript_rules_only", "transcript_rules"),
-    ("trace_checks_heavy", "trace_checks"),
-    ("custom_checks_only", "custom_checks"),
-    ("rubric_only", "llm_judge"),
+#
+# ``snapshot_kind="refusal"`` for ``state_checks_db_probes_only`` locks the
+# documented bundle-format-v1.0 limit: the snapshot substrate cannot serve
+# ``db_probe`` offline (the DSN is only reachable inside the task's docker
+# network). Bundle format v1.1 — pre-materialised probe rows — is deferred
+# under issue #1438.
+_ISOLATION_PACKS: list[ParityPackSpec] = [
+    ParityPackSpec("state_checks_jsonpath_only", "gradable", "state_checks"),
+    ParityPackSpec("state_checks_db_probes_only", "refusal", "state_checks"),
+    ParityPackSpec("transcript_rules_only", "gradable", "transcript_rules"),
+    ParityPackSpec("trace_checks_heavy", "gradable", "trace_checks"),
+    ParityPackSpec("custom_checks_only", "gradable", "custom_checks"),
+    ParityPackSpec("rubric_only", "gradable", "llm_judge"),
 ]
-_ISOLATION_PACK_DIRS = [_BASELINES_ROOT / name for name, _ in _ISOLATION_PACKS]
-_ISOLATION_PACK_IDS = [name for name, _ in _ISOLATION_PACKS]
-_ISOLATION_PACK_EXPECTED_BLOCK = dict(_ISOLATION_PACKS)
+_ISOLATION_PACK_DIRS = [_BASELINES_ROOT / spec.name for spec in _ISOLATION_PACKS]
+_ISOLATION_PACK_IDS = [spec.name for spec in _ISOLATION_PACKS]
+_ISOLATION_PACK_EXPECTED_BLOCK = {
+    spec.name: spec.expected_block for spec in _ISOLATION_PACKS if spec.expected_block is not None
+}
 
 _RUBRIC_ONLY_PACK_DIR = _BASELINES_ROOT / "rubric_only"
 
 # Composite packs that assert per-component parity across two or more seams.
-# The refusal case (``hash_and_all_four``) rides its own test — the grader leg
-# raises rather than producing a Grade — so it is excluded from this list.
+# ``hash_and_all_four`` — ``snapshot_kind="refusal"`` — locks the
+# grader-side hash refusal: hash grading fires before any substrate read,
+# so the snapshot leg surfaces the same message the live-callback leg
+# surfaces (substrate topology does not shift a hash refusal).
+_COMPOSITE_PACKS: list[ParityPackSpec] = [
+    ParityPackSpec("state_plus_transcript", "gradable"),
+    ParityPackSpec("state_plus_judge", "gradable"),
+    ParityPackSpec("all_four_no_hash", "gradable"),
+    ParityPackSpec("hash_and_all_four", "refusal"),
+]
 _COMPOSITE_PARITY_PACK_IDS: list[str] = [
-    "state_plus_transcript",
-    "state_plus_judge",
-    "all_four_no_hash",
+    spec.name for spec in _COMPOSITE_PACKS if spec.snapshot_kind == "gradable"
 ]
 _COMPOSITE_PARITY_PACK_DIRS = [_BASELINES_ROOT / name for name in _COMPOSITE_PARITY_PACK_IDS]
 _HASH_AND_ALL_FOUR_PACK_DIR = _BASELINES_ROOT / "hash_and_all_four"
+
+_SNAPSHOT_GRADABLE_PACK_SPECS: list[ParityPackSpec] = [
+    spec for spec in [*_ISOLATION_PACKS, *_COMPOSITE_PACKS] if spec.snapshot_kind == "gradable"
+]
+_SNAPSHOT_GRADABLE_PACK_DIRS = [
+    _BASELINES_ROOT / spec.name for spec in _SNAPSHOT_GRADABLE_PACK_SPECS
+]
+_SNAPSHOT_GRADABLE_PACK_IDS = [spec.name for spec in _SNAPSHOT_GRADABLE_PACK_SPECS]
+
+_SNAPSHOT_ISOLATION_GRADABLE_DIRS = [
+    _BASELINES_ROOT / spec.name for spec in _ISOLATION_PACKS if spec.snapshot_kind == "gradable"
+]
+_SNAPSHOT_ISOLATION_GRADABLE_IDS = [
+    spec.name for spec in _ISOLATION_PACKS if spec.snapshot_kind == "gradable"
+]
+
+_STATE_CHECKS_DB_PROBES_ONLY_PACK_DIR = _BASELINES_ROOT / "state_checks_db_probes_only"
+_SNAPSHOT_DB_PROBES_REFUSAL_FRAGMENT = "cannot serve db_probes offline"
+_SNAPSHOT_HASH_REFUSAL_FRAGMENT = "cannot execute hash-based grading"
 
 
 @pytest.mark.parametrize("pack_dir", _ISOLATION_PACK_DIRS, ids=_ISOLATION_PACK_IDS)
@@ -423,6 +494,240 @@ def test_regression_sim_leg_divergence_names_the_component(
 
     diverging = components_diff(runner_serialised, grader_serialised)
     assert diverging == ["trace_checks"], diverging
+
+
+@pytest.mark.parametrize(
+    "pack_dir",
+    _SNAPSHOT_ISOLATION_GRADABLE_DIRS,
+    ids=_SNAPSHOT_ISOLATION_GRADABLE_IDS,
+)
+def test_isolation_pack_parity_snapshot(
+    pack_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lane B: each snapshot-gradable isolation pack matches its baseline.
+
+    Drives :func:`run_via_snapshot_rpc` — the grader composite over a
+    :class:`SnapshotGradingSubstrate` reading a per-test-run bundle — and
+    asserts the resulting :class:`grader_pb2.Grade` serialises to the same
+    bytes as the pack's committed :file:`expected_grade.json` (the Lane A
+    baseline). Lane A owns baseline refresh; Lane B never rewrites.
+    """
+    pack = load_parity_pack(pack_dir)
+    grade = run_via_snapshot_rpc(pack, monkeypatch=monkeypatch)
+    serialised = serialise_grade(grade)
+    baseline = read_baseline(pack)
+    if serialised != baseline:
+        raise AssertionError(
+            _snapshot_baseline_divergence_message(
+                leg="grader_rpc_snapshot",
+                serialised=serialised,
+                baseline=baseline,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "pack_dir",
+    _COMPOSITE_PARITY_PACK_DIRS,
+    ids=_COMPOSITE_PARITY_PACK_IDS,
+)
+def test_composite_pack_parity_snapshot(
+    pack_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lane B: each snapshot-gradable composite pack matches its baseline.
+
+    Same shape as :func:`test_isolation_pack_parity_snapshot` over the
+    three composite packs whose grading blocks span multiple seams and
+    the snapshot substrate can serve every read. ``hash_and_all_four``
+    is refusal-mode in Lane B and rides
+    :func:`test_snapshot_rpc_refuses_hash_and_all_four`.
+    """
+    pack = load_parity_pack(pack_dir)
+    grade = run_via_snapshot_rpc(pack, monkeypatch=monkeypatch)
+    serialised = serialise_grade(grade)
+    baseline = read_baseline(pack)
+    if serialised != baseline:
+        raise AssertionError(
+            _snapshot_baseline_divergence_message(
+                leg="grader_rpc_snapshot",
+                serialised=serialised,
+                baseline=baseline,
+            )
+        )
+
+
+def test_snapshot_rpc_db_probes_surfaces_substrate_unreachable_in_reasons(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The snapshot leg cannot serve ``state_checks.db_probes`` offline; the
+    :class:`SubstrateUnreachableError` lands in the Grade's ``reasons`` text.
+
+    Locks the documented bundle-format-v1.0 limit for db_probes.
+    :meth:`SnapshotGradingSubstrate.db_probe` raises
+    :class:`SubstrateUnreachableError`; the state-check backend
+    (:class:`~tolokaforge.core.grading.default_state_check_backends.DbProbesStateCheckBackend`)
+    catches every ``substrate.db_probe`` exception per-probe and emits a
+    ``FAIL:`` reason line naming the exception, matching the fail-loud
+    contract shipped for db-probe connection errors. The Grade is
+    produced (not refused): ``components.state_checks == 0.0`` (every
+    probe failed) and ``reasons`` carries the "cannot serve db_probes
+    offline" fragment.
+
+    Bundle format v1.1 that pre-materialises probe rows is deferred
+    under issue #1438; once it lands, this pack graduates from Lane B's
+    refusal-in-reasons contract to full byte-parity.
+    """
+    pack = load_parity_pack(_STATE_CHECKS_DB_PROBES_ONLY_PACK_DIR)
+    grade = run_via_snapshot_rpc(pack, monkeypatch=monkeypatch)
+    projected = json.loads(serialise_grade(grade))
+    assert projected["components"]["state_checks"] == 0.0, projected["components"]
+    reasons = projected["reasons"]
+    assert _SNAPSHOT_DB_PROBES_REFUSAL_FRAGMENT in reasons, reasons
+
+
+def test_snapshot_rpc_refuses_hash_and_all_four(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The snapshot leg refuses a hash-enabled pack with the same message
+    the live-callback leg surfaces.
+
+    Hash refusal fires before any substrate read at
+    ``composite_dispatch.py:178-183``, so the message is grader-side and
+    substrate topology does not shift it. Locks that invariant: the
+    snapshot leg refuses on the same fragment Lane A pins.
+    """
+    pack = load_parity_pack(_HASH_AND_ALL_FOUR_PACK_DIR)
+    assert_snapshot_rpc_refuses(
+        pack,
+        monkeypatch=monkeypatch,
+        expected_error_fragment=_SNAPSHOT_HASH_REFUSAL_FRAGMENT,
+    )
+
+
+@pytest.mark.parametrize(
+    "pack_dir",
+    _SNAPSHOT_GRADABLE_PACK_DIRS,
+    ids=_SNAPSHOT_GRADABLE_PACK_IDS,
+)
+def test_regrade_parity_snapshot_replays(
+    pack_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Lane C: three sequential replays against one bundle produce identical
+    Grades.
+
+    Materialises a v1.0 grade bundle once, then dispatches
+    :func:`run_via_snapshot_rpc` three times with ``bundle_dir_override``
+    pointing at the same bytes. Asserts each replay's serialised Grade is
+    byte-identical to the pack's committed baseline (Lane A anchor) and
+    to the other two replays. The property is equality-of-inputs →
+    equality-of-outputs: the bundle bytes are fixed, so a divergence
+    across replays would mean the composite reached ``datetime.now()`` /
+    a mutable module-global / a process-local cache.
+
+    :class:`freezegun` is deliberately not used — the deterministic-bundle
+    property is the invariant here, not clock advancement. Follow-up:
+    strengthen with explicit 24 h advancement (adds a dev-dep).
+    """
+    pack = load_parity_pack(pack_dir)
+    bundle_dir = tmp_path / "regrade-bundle"
+    produce_snapshot_bundle(pack, monkeypatch=monkeypatch, bundle_dir=bundle_dir)
+    baseline = read_baseline(pack)
+    serialised_replays: list[str] = []
+    for _ in range(3):
+        grade = run_via_snapshot_rpc(
+            pack,
+            monkeypatch=monkeypatch,
+            bundle_dir_override=bundle_dir,
+        )
+        serialised_replays.append(serialise_grade(grade))
+    first_replay = serialised_replays[0]
+    for index, replay in enumerate(serialised_replays):
+        if replay != first_replay:
+            raise AssertionError(
+                _snapshot_baseline_divergence_message(
+                    leg=f"grader_rpc_snapshot replay #{index}",
+                    serialised=replay,
+                    baseline=first_replay,
+                )
+            )
+    if first_replay != baseline:
+        raise AssertionError(
+            _snapshot_baseline_divergence_message(
+                leg="grader_rpc_snapshot (regrade)",
+                serialised=first_replay,
+                baseline=baseline,
+            )
+        )
+
+
+def test_regrade_parity_snapshot_replays_db_probes_pack_are_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Lane C substrate-unreachable companion: three replays against the
+    db-probes pack produce byte-identical Grades.
+
+    Bundle production is substrate-independent for non-``db_probes``
+    reads, so the bundle materialises fine; each of three replays reaches
+    :meth:`SnapshotGradingSubstrate.db_probe`, which raises
+    :class:`SubstrateUnreachableError` per probe and lands in every
+    replay's ``reasons`` text through the state-check backend's catch.
+    Locks that Lane B's substrate-unreachable-in-reasons contract is
+    idempotent across replays.
+    """
+    pack = load_parity_pack(_STATE_CHECKS_DB_PROBES_ONLY_PACK_DIR)
+    bundle_dir = tmp_path / "regrade-bundle"
+    produce_snapshot_bundle(pack, monkeypatch=monkeypatch, bundle_dir=bundle_dir)
+    serialised_replays: list[str] = []
+    for _ in range(3):
+        grade = run_via_snapshot_rpc(
+            pack,
+            monkeypatch=monkeypatch,
+            bundle_dir_override=bundle_dir,
+        )
+        serialised_replays.append(serialise_grade(grade))
+    first_replay = serialised_replays[0]
+    for index, replay in enumerate(serialised_replays):
+        if replay != first_replay:
+            raise AssertionError(
+                _snapshot_baseline_divergence_message(
+                    leg=f"grader_rpc_snapshot db_probes replay #{index}",
+                    serialised=replay,
+                    baseline=first_replay,
+                )
+            )
+    projected = json.loads(first_replay)
+    assert _SNAPSHOT_DB_PROBES_REFUSAL_FRAGMENT in projected["reasons"], projected["reasons"]
+
+
+def _snapshot_baseline_divergence_message(
+    *,
+    leg: str,
+    serialised: str,
+    baseline: str,
+) -> str:
+    """Name the ``GradeComponents`` slots that diverged in the snapshot
+    leg's serialised Grade, mirroring the message
+    :func:`refresh_or_assert_baseline` emits for Lane A.
+    """
+    diverging = components_diff(serialised, baseline)
+    if diverging:
+        component_list = ", ".join(diverging)
+        return (
+            f"{leg} leg diverged from the baseline on components "
+            f"[{component_list}]; the snapshot substrate no longer produces "
+            "a byte-identical Grade for this pack."
+        )
+    return (
+        f"{leg} leg diverged from the baseline outside the components map "
+        "(score / reasons / detail lists differ but every component score "
+        "matches); the snapshot substrate no longer produces a byte-identical "
+        "Grade for this pack."
+    )
 
 
 def _fake_grade_trace_checks(*_args: Any, **_kwargs: Any) -> TraceChecksResult:

--- a/tests/unit/grader/test_grader_parity_harness_snapshot_shape.py
+++ b/tests/unit/grader/test_grader_parity_harness_snapshot_shape.py
@@ -1,0 +1,69 @@
+"""Scaffolding lock for :func:`run_via_snapshot_rpc` and friends.
+
+Proves the snapshot-leg helpers wire up end-to-end on one canonical pack
+(``rubric_only``) before the Stage 2 canonical parametrised tests broaden
+across the 10-pack matrix:
+
+* :func:`run_via_snapshot_rpc` returns a :class:`grader_pb2.Grade`;
+* :func:`produce_snapshot_bundle` materialises a bundle a downstream
+  :func:`run_via_snapshot_rpc` reads via ``bundle_dir_override``;
+* the composite's ``_substrate_cls`` factory constructs a fresh
+  :class:`SnapshotGradingSubstrate` per grade invocation (Lane C's
+  regrade-parity property depends on this — the composite closes its
+  substrate in ``finally`` and a reused instance would collapse after the
+  first close).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.utils.grader_parity_harness import (
+    load_parity_pack,
+    produce_snapshot_bundle,
+    run_via_snapshot_rpc,
+)
+from tolokaforge.core.grading import substrate as substrate_module
+from tolokaforge.grader import grader_pb2
+
+_RUBRIC_ONLY_PACK_DIR = (
+    Path(__file__).resolve().parents[2] / "canonical" / "grader_parity_baselines" / "rubric_only"
+)
+
+
+def test_run_via_snapshot_rpc_shape_and_fresh_substrate_per_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pack = load_parity_pack(_RUBRIC_ONLY_PACK_DIR)
+
+    construction_count = 0
+    original_init = substrate_module.SnapshotGradingSubstrate.__init__
+
+    def counting_init(self, bundle_view):  # type: ignore[no-untyped-def]
+        nonlocal construction_count
+        construction_count += 1
+        original_init(self, bundle_view)
+
+    monkeypatch.setattr(substrate_module.SnapshotGradingSubstrate, "__init__", counting_init)
+
+    first_grade = run_via_snapshot_rpc(pack, monkeypatch=monkeypatch)
+    assert isinstance(first_grade, grader_pb2.Grade)
+
+    bundle_dir = tmp_path / "regrade-bundle"
+    produce_snapshot_bundle(pack, monkeypatch=monkeypatch, bundle_dir=bundle_dir)
+    assert (bundle_dir / "manifest.json").is_file()
+
+    replay_grade = run_via_snapshot_rpc(
+        pack, monkeypatch=monkeypatch, bundle_dir_override=bundle_dir
+    )
+    assert isinstance(replay_grade, grader_pb2.Grade)
+
+    assert construction_count >= 2, (
+        "expected at least two SnapshotGradingSubstrate constructions across "
+        "one full run and one replay; got "
+        f"{construction_count} — factory reused an instance, which would "
+        "collapse Lane C's regrade-parity property"
+    )

--- a/tests/utils/grader_parity_harness.py
+++ b/tests/utils/grader_parity_harness.py
@@ -33,11 +33,13 @@ from __future__ import annotations
 
 import base64
 import json
+import tempfile
 from collections.abc import Iterator
 from concurrent import futures
 from contextlib import contextmanager
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -47,11 +49,17 @@ import yaml
 from google.protobuf import json_format
 
 from tolokaforge.core.grading import db_probes as db_probes_module
-from tolokaforge.core.grading.bundle import normalise_floats
+from tolokaforge.core.grading.bundle import load_grade_bundle, normalise_floats
+from tolokaforge.core.grading.bundle_producer import serialize_bundle_from_substrate
+from tolokaforge.core.grading.substrate import (
+    InProcessGradingSubstrate,
+    SnapshotGradingSubstrate,
+)
+from tolokaforge.core.grading.transcript_wire import decode_transcript_wire
 from tolokaforge.core.llm.client import GenerationResult
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.logging import StructuredLogger
-from tolokaforge.core.models import ModelConfig, ToolCall
+from tolokaforge.core.models import ModelConfig, ToolCall, Trajectory
 from tolokaforge.core.trial_grader import GradingFailedError
 from tolokaforge.grader import grader_pb2
 from tolokaforge.grader.composite_dispatch import GraderCompositeDispatch
@@ -70,6 +78,7 @@ from tolokaforge.runner.models import (
     StateResponse,
     TaskDescription,
 )
+from tolokaforge.runner.protocol import parse_termination_reason
 from tolokaforge.runner.service import RunnerServiceImpl, TrialContextRuntime
 from tolokaforge.runner.substrate_service import SubstrateServicer
 
@@ -528,6 +537,143 @@ def _build_grade_dispatch(pack: ParityPack, *, substrate_address: str) -> GradeD
     )
 
 
+_TRAJECTORY_FIXED_TS = datetime(2026, 1, 1, tzinfo=UTC)
+"""Deterministic timestamp for the two :class:`Trajectory` datetime fields
+the snapshot leg synthesises. Pinning both ``start_ts`` and ``end_ts`` keeps
+``trajectory.json`` bytes reproducible across sessions along those two
+axes. :attr:`Message.ts` retains its wall-clock default: the bundle carries
+that timestamp per message but no grader-side code reads
+``trajectory.json``, so Grade equality still holds. A future bundle-digest
+lockfile must pin ``Message.ts`` before it can lock those bytes."""
+
+
+class _NoOpDBReader:
+    """Fail-loud :class:`DBReader` stand-in for the snapshot-leg substrate
+    used at bundle-production time.
+
+    :func:`serialize_bundle_from_substrate` reads
+    :meth:`~GradingSubstrate.initial_state`,
+    :meth:`~GradingSubstrate.final_state`,
+    :meth:`~GradingSubstrate.final_state_stable`, and
+    :meth:`~GradingSubstrate.filesystem_root` off its substrate — never the
+    DB reader. This stub raises if anything reaches for that seam, so a
+    producer change reaching for DB rows surfaces at the harness rather
+    than silently returning an empty view.
+    """
+
+    def get_state(self, tables: list[str] | None = None) -> dict[str, Any]:  # noqa: ARG002
+        raise AssertionError(
+            "parity snapshot leg exposes no DBReader — bundle production "
+            "reads state via initial_state() / final_state() only."
+        )
+
+    def query(self, jsonpath: str) -> dict[str, Any]:  # noqa: ARG002
+        raise AssertionError(
+            "parity snapshot leg exposes no DBReader — bundle production "
+            "reads state via initial_state() / final_state() only."
+        )
+
+
+def _synthesise_trajectory(pack: ParityPack) -> Trajectory:
+    """Build the :class:`Trajectory` the bundle producer serialises.
+
+    Splits ``pack.trial_id`` on ``':'`` to derive ``task_id`` /
+    ``trial_index`` (the harness pack convention:
+    ``{task_id}:{trial_index}``). Decodes ``pack.llm_messages_json`` back
+    into a :class:`Message` list via :func:`decode_transcript_wire`. Maps
+    ``pack.termination_reason`` through :func:`parse_termination_reason`.
+    Pins ``start_ts`` and ``end_ts`` to :data:`_TRAJECTORY_FIXED_TS`.
+
+    Other :class:`Trajectory` fields default per Pydantic
+    ``Field(default_factory=...)``. ``grade`` is ``None`` — the trajectory
+    is the *input* to grading here, not the graded record.
+    """
+    task_id, sep, trial_index_str = pack.trial_id.partition(":")
+    if not sep or not trial_index_str.isdigit():
+        raise ValueError(
+            f"pack.trial_id {pack.trial_id!r} does not follow the "
+            "'{task_id}:{trial_index}' convention the snapshot leg requires"
+        )
+    messages_list: list[dict[str, Any]] = json.loads(pack.llm_messages_json)
+    return Trajectory(
+        task_id=task_id,
+        trial_index=int(trial_index_str),
+        start_ts=_TRAJECTORY_FIXED_TS,
+        end_ts=_TRAJECTORY_FIXED_TS,
+        messages=decode_transcript_wire(messages_list),
+        termination_reason=parse_termination_reason(pack.termination_reason),
+    )
+
+
+def _build_bundle_substrate(pack: ParityPack) -> InProcessGradingSubstrate:
+    """Build the :class:`InProcessGradingSubstrate`
+    :func:`serialize_bundle_from_substrate` reads.
+
+    Parity packs model a stationary trial: :meth:`initial_state`,
+    :meth:`final_state`, and :meth:`final_state_stable` all resolve to
+    ``pack.task_description.initial_state.tables`` — the same authored bytes
+    the live-callback substrate serves through its ``_FakeDBServiceClient``.
+
+    ``filesystem_root=pack.directory`` — bundle format v1.0 requires a
+    non-``None`` root at ``bundle_producer.py:75-80``; the pack directory
+    is a real folder, so the producer's ``filesystem.tar`` gets non-empty
+    bytes. Grading code never inspects the tarball contents for parity
+    packs, so the Grade output is unaffected.
+
+    ``filesystem_state_factory=lambda: None`` — parity packs do not grade
+    ``$.filesystem[...]``; ``None`` is the first-class "no workspace tree"
+    answer the composite already handles.
+    """
+    tables: dict[str, Any] = dict(pack.task_description.initial_state.tables)
+    return InProcessGradingSubstrate(
+        db_reader=_NoOpDBReader(),  # type: ignore[arg-type]
+        knowledge_search=None,
+        filesystem_root=pack.directory,
+        initial_state=tables,
+        final_state=tables,
+        final_state_stable_factory=lambda: tables,
+        filesystem_state_factory=lambda: None,
+    )
+
+
+def _produce_bundle_into(pack: ParityPack, *, out_dir: Path) -> None:
+    """Materialise a v1.0 grade bundle for ``pack`` into ``out_dir``.
+
+    Callers own ``out_dir`` lifecycle. The substrate is constructed,
+    driven through :func:`serialize_bundle_from_substrate`, and closed
+    within this helper.
+    """
+    substrate = _build_bundle_substrate(pack)
+    try:
+        serialize_bundle_from_substrate(
+            substrate=substrate,
+            trial_id=pack.trial_id,
+            out_dir=out_dir,
+            trajectory=_synthesise_trajectory(pack),
+            task_description=pack.task_description,
+        )
+    finally:
+        substrate.close()
+
+
+@contextmanager
+def _bundle_dir_context(pack: ParityPack, override: Path | None) -> Iterator[Path]:
+    """Yield the ``bundle_dir`` one snapshot dispatch reads from.
+
+    ``override`` (Lane C's pre-materialised bundle) is yielded verbatim
+    and never cleaned up — the caller owns it. ``None`` materialises a
+    fresh bundle into a :class:`tempfile.TemporaryDirectory` that is
+    removed on exit.
+    """
+    if override is not None:
+        yield override
+        return
+    with tempfile.TemporaryDirectory(prefix="parity-snapshot-bundle-") as tmpdir:
+        bundle_dir = Path(tmpdir)
+        _produce_bundle_into(pack, out_dir=bundle_dir)
+        yield bundle_dir
+
+
 def run_via_runner_rpc(
     pack: ParityPack,
     *,
@@ -611,6 +757,112 @@ def assert_grader_rpc_refuses(
             f"grader refused but the message does not carry the declared fragment "
             f"{expected_error_fragment!r}: {str(excinfo.value)!r}"
         )
+
+
+def run_via_snapshot_rpc(
+    pack: ParityPack,
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    bundle_dir_override: Path | None = None,
+) -> grader_pb2.Grade:
+    """Drive :class:`GraderCompositeDispatch` end-to-end with substrate reads
+    served by a :class:`SnapshotGradingSubstrate` over a produced bundle.
+
+    A :class:`_running_runner` still boots so the wire dispatch carries a
+    non-empty ``runner_substrate_address`` — the composite refuses an empty
+    address up front. The monkeypatched ``_substrate_cls`` factory ignores
+    the address, so the runner is never dialled.
+
+    ``bundle_dir_override`` — when supplied, the caller owns the bundle
+    bytes on disk and the leg reads them verbatim. Lane C uses this to
+    replay a single materialised bundle across three sequential dispatches.
+    ``None`` materialises a fresh bundle in a scoped
+    :class:`tempfile.TemporaryDirectory`.
+
+    The substrate factory closure captures ``bundle_dir`` rather than a
+    substrate instance and returns a *fresh*
+    :class:`SnapshotGradingSubstrate` per call:
+    :meth:`GraderCompositeDispatch.grade` closes its substrate in
+    ``finally`` (``composite_dispatch.py:224-225``) and
+    :meth:`SnapshotGradingSubstrate.close` drops the extracted-filesystem
+    tmpdir (``substrate.py:610-616``), so a reused instance would collapse
+    after the first ``close``. Fresh-from-bytes per invocation is the
+    "same bundle, N replays" property Lane C locks.
+
+    The ``_substrate_cls`` monkeypatch is a test seam. Production
+    grader-side substrate selection driven off wire fields lands under
+    follow-up #1453; the harness's injection here does not shape any
+    shipped API.
+    """
+    _install_scripted_client(monkeypatch, pack.judge_script)
+    if pack.db_probe_rows:
+        _install_db_probe_rows(monkeypatch, pack)
+    with (
+        _running_runner(pack) as ctx,
+        _bundle_dir_context(pack, bundle_dir_override) as bundle_dir,
+    ):
+
+        def _substrate_factory(
+            _address: str,  # noqa: ARG001
+            _trial_id: str,  # noqa: ARG001
+        ) -> SnapshotGradingSubstrate:
+            return SnapshotGradingSubstrate(load_grade_bundle(bundle_dir))
+
+        dispatch = _build_grade_dispatch(pack, substrate_address=ctx.substrate_address)
+        composite = GraderCompositeDispatch(
+            logger=StructuredLogger(name="parity-gate-grader-snapshot")  # type: ignore[arg-type]
+        )
+        monkeypatch.setattr(composite, "_substrate_cls", _substrate_factory)
+        grade = composite.grade(dispatch)
+        assert grade is not None, "grader_rpc snapshot leg produced no verdict"
+        return _grade_to_wire(grade)
+
+
+def assert_snapshot_rpc_refuses(
+    pack: ParityPack,
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    expected_error_fragment: str,
+) -> None:
+    """Assert :func:`run_via_snapshot_rpc` raises :class:`GradingFailedError`
+    whose message contains ``expected_error_fragment``.
+
+    Covers two refusal shapes the snapshot leg lands on:
+
+    * A pack declaring ``state_checks.db_probes`` reaches
+      :meth:`SnapshotGradingSubstrate.db_probe`, which raises
+      :class:`SubstrateUnreachableError` — the composite translates it to
+      :class:`GradingFailedError` at ``composite_dispatch.py:220-223``. The
+      fragment "cannot serve db_probes offline" pins that translation.
+    * A pack declaring ``state_checks.hash_enabled`` refuses grader-side
+      before any substrate read; the fragment "cannot execute hash-based
+      grading" pins the same grader-side message the live-callback leg
+      surfaces. Substrate topology does not shift a hash refusal.
+    """
+    with pytest.raises(GradingFailedError) as excinfo:
+        run_via_snapshot_rpc(pack, monkeypatch=monkeypatch)
+    assert expected_error_fragment in str(excinfo.value), (
+        f"snapshot leg refused but the message does not carry the declared "
+        f"fragment {expected_error_fragment!r}: {str(excinfo.value)!r}"
+    )
+
+
+def produce_snapshot_bundle(
+    pack: ParityPack,
+    *,
+    monkeypatch: pytest.MonkeyPatch,  # noqa: ARG001
+    bundle_dir: Path,
+) -> None:
+    """Materialise a v1.0 grade bundle for ``pack`` into ``bundle_dir``.
+
+    Lane C helper: run once against a caller-owned empty directory, then
+    dispatch ``run_via_snapshot_rpc(pack, monkeypatch=..., bundle_dir_override=bundle_dir)``
+    N times to lock the regrade-parity property. The ``monkeypatch``
+    argument is required for API symmetry with the other snapshot-leg
+    helpers, but bundle production reaches no monkeypatched seams —
+    :class:`_ScriptedClient` and the probe-rows fake are grade-time only.
+    """
+    _produce_bundle_into(pack, out_dir=bundle_dir)
 
 
 def serialise_grade(grade: runner_pb2.Grade | grader_pb2.Grade) -> str:
@@ -791,12 +1043,15 @@ __all__ = [
     "REFRESH_BASELINES_OPTION",
     "ParityPack",
     "assert_grader_rpc_refuses",
+    "assert_snapshot_rpc_refuses",
     "components_diff",
     "load_parity_pack",
+    "produce_snapshot_bundle",
     "read_baseline",
     "refresh_or_assert_baseline",
     "run_via_grader_rpc",
     "run_via_runner_rpc",
+    "run_via_snapshot_rpc",
     "serialise_grade",
     "should_refresh_baselines",
     "write_baseline",

--- a/tests/utils/grader_parity_harness.py
+++ b/tests/utils/grader_parity_harness.py
@@ -537,6 +537,38 @@ def _build_grade_dispatch(pack: ParityPack, *, substrate_address: str) -> GradeD
     )
 
 
+class _ParityHarnessSnapshotSubstrate(SnapshotGradingSubstrate):
+    """:class:`SnapshotGradingSubstrate` variant the parity gate reads through.
+
+    Parity packs model a stationary trial with **no agent workspace tree**;
+    the pack directory only carries YAML fixtures. Bundle format v1.0
+    refuses a ``None`` ``filesystem_root`` at
+    :func:`serialize_bundle_from_substrate` (``bundle_producer.py:75-80``),
+    so the harness passes ``pack.directory`` at bundle-production time and
+    ``filesystem.tar`` picks up the pack's YAML files. That inflates the
+    Snapshot substrate's :meth:`filesystem_root` above the Lane A baseline:
+    :class:`~tolokaforge.core.grading.substrate_live.LiveRunnerCallbackGradingSubstrate`
+    returns ``None`` for a parity pack (empty workspace + non-existent
+    root), which suppresses the judge's ``read_file`` registration at
+    ``judge.py:500-503``, while the base :class:`SnapshotGradingSubstrate`
+    extracts the tar to a tmpdir and returns a non-``None`` root.
+
+    Overriding :meth:`filesystem_root` to ``None`` at the parity seam
+    restores byte-parity: parity packs semantically have no workspace, and
+    the harness's live-callback leg encodes that as ``None``. Production
+    grade-bundle consumers still see the base behaviour — this subclass is
+    a test seam only, registered via
+    :attr:`GraderCompositeDispatch._substrate_cls` inside
+    :func:`run_via_snapshot_rpc`.
+
+    A future bundle format v1.1 with an explicit "no workspace" encoding
+    would remove this seam; tracked as a Lane B follow-up.
+    """
+
+    def filesystem_root(self) -> Path | None:  # type: ignore[override]
+        return None
+
+
 _TRAJECTORY_FIXED_TS = datetime(2026, 1, 1, tzinfo=UTC)
 """Deterministic timestamp for the two :class:`Trajectory` datetime fields
 the snapshot leg synthesises. Pinning both ``start_ts`` and ``end_ts`` keeps
@@ -805,8 +837,8 @@ def run_via_snapshot_rpc(
         def _substrate_factory(
             _address: str,  # noqa: ARG001
             _trial_id: str,  # noqa: ARG001
-        ) -> SnapshotGradingSubstrate:
-            return SnapshotGradingSubstrate(load_grade_bundle(bundle_dir))
+        ) -> _ParityHarnessSnapshotSubstrate:
+            return _ParityHarnessSnapshotSubstrate(load_grade_bundle(bundle_dir))
 
         dispatch = _build_grade_dispatch(pack, substrate_address=ctx.substrate_address)
         composite = GraderCompositeDispatch(


### PR DESCRIPTION
Closes #1360. Milestone #39 (Grader v3), Phase C item 22 — expand parity gate from 1 to 3 lanes + ship mechanical opt-in defaults lock.

## Summary

Milestone-39 shipped a 3rd substrate topology (`SnapshotGradingSubstrate`) and an offline regrade path but neither was guarded by the byte-parity 10-pack gate. This PR:
- **Lane A (unchanged)**: 10 packs × `runner_rpc` vs `grader_rpc` — the shipping gate.
- **Lane B (new)**: 10 packs × `runner_rpc` vs `grader_rpc + snapshot=on` (`SnapshotGradingSubstrate`) — byte-parity across all 3 substrate topologies for the 8 snapshot-gradable packs; refusal contract for `state_checks_db_probes_only` (bundle v1.0 limit) and `hash_and_all_four` (substrate topology doesn't shift hash refusal).
- **Lane C (new — regrade parity property)**: 8 snapshot-gradable packs × 3 sequential in-process replays against same frozen bundle bytes produce byte-identical `Grade`.
- **Opt-in defaults lock**: `tests/canonical/test_grader_defaults.py` asserts `SnapshotBundleConfig.enabled=False`, `GraderConfig.expose_substrate=False`, `GraderConfig.snapshot=None` defaults. A PR flipping any default fails CI unless it also edits this file.

## Commit series

1. `289d38d8` — Stage 1: `grader_parity_harness.py` snapshot machinery (`run_via_snapshot_rpc`, `assert_snapshot_rpc_refuses`, `produce_snapshot_bundle`, Trajectory synthesis, `_ParityHarnessSnapshotSubstrate`) + scaffolding test at `tests/unit/grader/`. Fresh `SnapshotGradingSubstrate` per invocation (`bundle_dir` captured, not substrate instance) — required for Lane C's 3-replay property because composite closes substrate in `finally`.
2. `d49c36b8` — Stage 2: Lane B (5 isolation + 3 composite parity tests + 2 refusal-contract tests) + Lane C (regrade-parity property + refusal-idempotent property). `ParityPackSpec` frozen dataclass migration for `_ISOLATION_PACKS` + `_COMPOSITE_PACKS` with `snapshot_kind: Literal["gradable", "refusal"]`. Doc updates (`tests/README.md`, `docs/GRADER_SERVICE.md`, `docs/GRADE_BUNDLE.md`).
3. `bfb1c3f4` — Stage 3: `tests/canonical/test_grader_defaults.py` (3 mechanical assertions via `BaseModel.model_fields` — not `model_dump()` — so rename or Pydantic-v2 default-shape change surfaces at the exact assertion). Doc sentence in `docs/GRADER_SERVICE.md` SubstrateService opt-in section.

## Design choices

| Decision | Rationale |
|---|---|
| Monkeypatch `GraderCompositeDispatch._substrate_cls` (test seam) | Production wire-driven substrate selection is #1453. |
| Bundle materialisation per-test-run (no committed digests) | Test runtime; a future bundle-manifest-digest lockfile per pack is a follow-up when needed. |
| `hash_and_all_four` asserts same refusal in Lane B/C | Locks "substrate topology does not shift hash refusal" invariant. |
| `state_checks_db_probes_only` refusal contract | Bundle v1.0 carries no probe rows — documented limit, not regression. Bundle v1.1 unlocks it (#1439). |
| No `freezegun` for Lane C | Input-equality → output-equality is the property; 3 sequential in-process replays cover it. |
| Colocate Lane B + C in existing `test_grader_parity_reference.py` | Parity gate stays one file. |
| `ParityPackSpec` frozen dataclass (not 3-tuple) | Named field access more readable; two broken 2-tuple call sites at lines 64-66 explicitly migrated (critic r1 F5). |
| Fresh `SnapshotGradingSubstrate(load_grade_bundle(bundle_dir))` per invocation | Critic r1 🟠 F2 — dispatch closes substrate in `finally`; substrate reuse would collapse Lane C 3-replay property. |
| `filesystem_root=pack.directory` + `filesystem_state_factory=lambda: None` | Critic r1 🟠 F1 — bundle_producer refuses `None` root; pack YAML rides into `filesystem.tar` (grading code never inspects tarball contents for parity packs; Grade unaffected). |
| `_ParityHarnessSnapshotSubstrate` test-seam subclass overrides `filesystem_root() → None` | Matches `LiveRunnerCallbackGradingSubstrate` behavior for parity packs (no workspace tree). Documented as test seam; bundle v1.1 with explicit "no workspace" encoding would remove it. |
| `db_probes` test asserts on `Grade.reasons` (not `pytest.raises`) | `DbProbesStateCheckBackend.query()` catches per-probe (`default_state_check_backends.py:143-154`) and emits `FAIL:` reason line; `SubstrateUnreachableError` doesn't propagate. Plan drift documented. |
| Module-field access in defaults lock (`.model_fields[k].default`, not instance `model_dump()`) | Rename or Pydantic-v2 default-shape change surfaces at the exact assertion. |

## Test plan

- [x] Stage 1: `pytest tests/unit/grader/test_grader_parity_harness_snapshot_shape.py` — 1/1.
- [x] Stage 2: `pytest tests/canonical/test_grader_parity_reference.py` — 44/44 (25 Lane A + 19 new Lane B/C).
- [x] Stage 3: `pytest tests/canonical/test_grader_defaults.py` — 3/3.
- [x] `uv run lint-imports` — 10/10 (unchanged).
- [x] `mcp__dev__lint_check` + `format_check` — clean.

## Follow-ups filed / referenced during discovery

- **#1453** — grader-side dispatch reading `bundle_manifest_json` / `bundle_parts_uri` and building `SnapshotGradingSubstrate` (Lane B production-wire variant is monkeypatched today).
- **#1439** — bundle format v1.1 pre-materialised db_probes sidecar (unlocks `state_checks_db_probes_only` offline grading).

## Not in this PR

- Production wire-driven substrate injection on `GraderCompositeDispatch` (#1453 — Lane B monkeypatches today).
- Bundle-manifest-digest lockfile per pack (would add byte-lock for bundle format).
- Cross-process 3-replay variant for Lane C (in-process sequential replay is sufficient — no known cross-call state).