### PR TITLE
feat(engine-loop): per-model default_max_turns on ModelCapabilities

### DIFF
--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -1905,6 +1905,21 @@ the precedence body is pinned by
 [`tests/unit/test_conductor.py`](../tests/unit/test_conductor.py)
 (`TestResolveMaxTurns`).
 
+The `gemini_31_pro_preview` preset opts in at
+`default_max_turns: 90`. Gemini 3.1 Pro's per-turn edit style is more
+granular than the framework baseline, so the same absolute budget
+exhausts earlier on tasks a coarser-grained model completes in fewer
+turns; 90 is the conservative lift over the 50-turn framework default.
+The overlay carries the generic `gemini` policy trio (`reasoning_codec`,
+`schema_sanitizer`, `response_policy`) verbatim, so the preset's only
+functional divergence from the shared `gemini` route is the turn-budget
+default. Exact-match globs (`google/gemini-3.1-pro-preview` and its
+OpenRouter-prefixed variant) sit BEFORE the generic `gemini` block in
+[`model_presets.yaml`](../tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml)
+so first-match-wins picks up the overlay; adjacent Pro slugs (2.5, 3.0,
+3.1 GA) and every Flash lineage member continue to route through the
+generic `gemini` preset and inherit the framework default.
+
 ## `response_policy`
 
 Tool-call argument post-processing.

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -1866,6 +1866,45 @@ the loop-layer behaviour and the helper contract are pinned by
 and
 [`tests/unit/test_tool_output_truncation.py`](../tests/unit/test_tool_output_truncation.py).
 
+### Per-model turn-budget default
+
+`ModelCapabilities.default_max_turns: int | None` is the preset-level value
+default for the per-trial turn budget when the task did not declare its own
+`TaskConfig.max_turns`. Different models converge to a done state in
+different numbers of steps on the same task: a model whose per-turn edit
+style is more granular (more per-turn tool calls, smaller diffs per call)
+exhausts a given absolute budget on a task that a coarser-grained model
+completes in fewer turns. A first-class preset knob for the per-trial base
+budget is a general-harness improvement rather than a per-model workaround.
+`None` (the default) leaves the engine-wide fallback
+`DEFAULT_MAX_TURNS = 50` in place for presets that do not name the key.
+
+The conductor's
+[`resolve_max_turns`](../tolokaforge/core/conductor.py) composes three
+inputs into the effective per-trial budget:
+
+* `TaskConfig.max_turns` — task-declared. When set, it is authoritative for
+  the task's own semantics.
+* `OrchestratorConfig.max_turns` — the operator's run-level ceiling. Always
+  applies as a `min(base, run_cap)` clamp when set.
+* `ModelCapabilities.default_max_turns` — the preset-level value default.
+  Consulted only when the task did not pin its own budget; it supplies the
+  base value that the operator's cap then ceilings.
+
+Precedence:
+
+1. Task pinned `max_turns` → effective = `min(task_max_turns, run_cap)` when
+   both set, else `task_max_turns`.
+2. Task did not pin `max_turns` → base = `default_max_turns` when set, else
+   `DEFAULT_MAX_TURNS = 50`; effective = `min(base, run_cap)` when the run
+   cap is set, else `base`.
+
+Preset routing is pinned by
+[`tests/canonical/test_default_max_turns_preset_routing.py`](../tests/canonical/test_default_max_turns_preset_routing.py);
+the precedence body is pinned by
+[`tests/unit/test_conductor.py`](../tests/unit/test_conductor.py)
+(`TestResolveMaxTurns`).
+
 ## `response_policy`
 
 Tool-call argument post-processing.

--- a/tests/canonical/test_default_max_turns_preset_routing.py
+++ b/tests/canonical/test_default_max_turns_preset_routing.py
@@ -10,8 +10,7 @@ the per-trial turn budget:
   evidence: 8/8 T-Bench balanced-10 head-to-head failures on the
   2026-09-04 sweep hit ``termination_reason: max_turns`` at exactly
   turn 60 with mid-productive trajectories at the cutoff. 90 is the
-  conservative lift over the 50-turn engine default (issue #1493's
-  suggested lower bound).
+  conservative lift over the 50-turn engine default.
 
 The :attr:`ModelCapabilities.default_max_turns` slot fills the gap when
 neither the task's ``TaskConfig.max_turns`` nor the operator's

--- a/tests/canonical/test_default_max_turns_preset_routing.py
+++ b/tests/canonical/test_default_max_turns_preset_routing.py
@@ -1,18 +1,32 @@
 """Canonical test — preset → ``default_max_turns`` routing.
 
-Locks the per-model default for the per-trial turn budget. The
-:attr:`ModelCapabilities.default_max_turns` slot fills the gap when
-neither the task's ``TaskConfig.max_turns`` nor the operator's
-``OrchestratorConfig.max_turns`` pinned a budget; ``None`` (the default)
-leaves the engine-wide fallback ``DEFAULT_MAX_TURNS = 50`` in place.
+Pins the single model preset that opts into the per-model default for
+the per-trial turn budget:
 
-Every tracked preset resolves to ``default_max_turns is None`` — a
+* ``gemini_31_pro_preview`` — Gemini 3.1 Pro's per-turn edit style is
+  more granular than the framework baseline (more per-turn tool calls,
+  smaller diffs per call), so the same absolute budget exhausts earlier
+  on tasks a coarser-grained model completes in fewer turns. Live
+  evidence: 8/8 T-Bench balanced-10 head-to-head failures on the
+  2026-09-04 sweep hit ``termination_reason: max_turns`` at exactly
+  turn 60 with mid-productive trajectories at the cutoff. 90 is the
+  conservative lift over the 50-turn engine default (issue #1493's
+  suggested lower bound).
+
+The :attr:`ModelCapabilities.default_max_turns` slot fills the gap when
+neither the task's ``TaskConfig.max_turns`` nor the operator's
+``OrchestratorConfig.max_turns`` pinned a budget; ``None`` (the
+default) leaves the engine-wide fallback ``DEFAULT_MAX_TURNS = 50`` in
+place.
+
+Every other preset resolves to ``default_max_turns is None`` — a
 per-model default changes the effective turn budget on the task-unset
-path across every operator that has not clamped ``orchestrator.max_turns``
-below the preset value, so the opt-in is per-preset with observed
-evidence rather than a global default. If a new preset opted in
-unintentionally this test fails and the right move is to remove the
-entry from the preset registry, not to mute the assertion.
+path across every operator that has not clamped
+``orchestrator.max_turns`` below the preset value, so the opt-in is
+per-preset with observed evidence rather than a global default. If a
+new preset opted in unintentionally this test fails and the right move
+is to remove the entry from the preset registry, not to mute the
+assertion.
 """
 
 from __future__ import annotations
@@ -22,6 +36,12 @@ import pytest
 from tolokaforge.core.llm import build_capabilities
 
 pytestmark = pytest.mark.canonical
+
+
+_DEFAULT_MAX_TURNS_OPT_IN_MODELS = [
+    ("google/gemini-3.1-pro-preview", "openrouter", 90),
+    ("openrouter/google/gemini-3.1-pro-preview", "openrouter", 90),
+]
 
 
 _DEFAULT_MAX_TURNS_NONE_MODELS = [
@@ -34,10 +54,19 @@ _DEFAULT_MAX_TURNS_NONE_MODELS = [
     "qwen/qwen3-coder",
     "moonshotai/kimi-k3",
     "moonshotai/kimi-k2.6",
-    "google/gemini-3.1-pro-preview",
     "google/gemini-3.5-flash",
     "google/gemini-3.7-flash",
 ]
+
+
+@pytest.mark.parametrize(("model", "provider", "expected"), _DEFAULT_MAX_TURNS_OPT_IN_MODELS)
+def test_opted_in_presets_carry_default_max_turns(model: str, provider: str, expected: int) -> None:
+    caps = build_capabilities(model, provider)
+    assert caps.default_max_turns == expected, (
+        f"{model!r} default_max_turns drifted: expected {expected}, "
+        f"got {caps.default_max_turns}. The opt-in is data on the preset "
+        "overlay — an intentional change lands here."
+    )
 
 
 @pytest.mark.parametrize("model", _DEFAULT_MAX_TURNS_NONE_MODELS)

--- a/tests/canonical/test_default_max_turns_preset_routing.py
+++ b/tests/canonical/test_default_max_turns_preset_routing.py
@@ -1,0 +1,52 @@
+"""Canonical test — preset → ``default_max_turns`` routing.
+
+Locks the per-model default for the per-trial turn budget. The
+:attr:`ModelCapabilities.default_max_turns` slot fills the gap when
+neither the task's ``TaskConfig.max_turns`` nor the operator's
+``OrchestratorConfig.max_turns`` pinned a budget; ``None`` (the default)
+leaves the engine-wide fallback ``DEFAULT_MAX_TURNS = 50`` in place.
+
+Every tracked preset resolves to ``default_max_turns is None`` — a
+per-model default changes the effective turn budget on the task-unset
+path across every operator that has not clamped ``orchestrator.max_turns``
+below the preset value, so the opt-in is per-preset with observed
+evidence rather than a global default. If a new preset opted in
+unintentionally this test fails and the right move is to remove the
+entry from the preset registry, not to mute the assertion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.llm import build_capabilities
+
+pytestmark = pytest.mark.canonical
+
+
+_DEFAULT_MAX_TURNS_NONE_MODELS = [
+    "openai/gpt-4o",
+    "anthropic/claude-opus-4.7",
+    "anthropic/claude-sonnet-4.7",
+    "anthropic/claude-opus-5",
+    "openai/gpt-5.5",
+    "x-ai/grok-4",
+    "qwen/qwen3-coder",
+    "moonshotai/kimi-k3",
+    "moonshotai/kimi-k2.6",
+    "google/gemini-3.1-pro-preview",
+    "google/gemini-3.5-flash",
+    "google/gemini-3.7-flash",
+]
+
+
+@pytest.mark.parametrize("model", _DEFAULT_MAX_TURNS_NONE_MODELS)
+def test_non_opted_in_presets_leave_default_max_turns_none(model: str) -> None:
+    caps = build_capabilities(model, "openrouter")
+    assert caps.default_max_turns is None, (
+        f"{model!r} must resolve to default_max_turns=None. Only presets "
+        "whose observed convergence behaviour warrants a per-model turn "
+        "budget opt in; adding a default elsewhere silently changes the "
+        "effective per-trial budget under existing operators. "
+        f"Got: {caps.default_max_turns}."
+    )

--- a/tests/canonical/test_terminal_bench_harness_mode.py
+++ b/tests/canonical/test_terminal_bench_harness_mode.py
@@ -185,6 +185,7 @@ def harness_trial(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
         config = MagicMock()
         config.orchestrator.timeouts.episode_s = episode_s
+        config.orchestrator.max_turns = None
         # A real config value: the turn-loop branch validates the probe budget
         # against the episode budget, and a MagicMock reads as enabled.
         config.orchestrator.rate_limit_probe = RateLimitProbeConfig()
@@ -194,6 +195,7 @@ def harness_trial(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         grader = _RecordingGrader()
         agent_client = MagicMock()
         agent_client.capabilities.schema_sanitizer.sanitize.side_effect = lambda s: s
+        agent_client.capabilities.default_max_turns = None
         agent_client.classify_loop_error.side_effect = lambda exc: classify_loop_error(exc, ())
 
         conductor = InProcessConductor(

--- a/tests/unit/test_conductor.py
+++ b/tests/unit/test_conductor.py
@@ -343,6 +343,9 @@ class TestResolveMaxTurns:
 
     def test_both_unset_falls_back_to_engine_default(self) -> None:
         assert resolve_max_turns(None, None) == DEFAULT_MAX_TURNS == 50
+        # Explicit-None third arg is identical to the 2-arg call — verify
+        # the widening did not add a subtle branch.
+        assert resolve_max_turns(None, None, None) == DEFAULT_MAX_TURNS == 50
 
     def test_run_cap_clamps_higher_task_value(self) -> None:
         assert resolve_max_turns(100, 30) == 30
@@ -368,8 +371,11 @@ class TestResolveMaxTurns:
     def test_task_and_run_both_still_min(self) -> None:
         assert resolve_max_turns(45, 60, 90) == 45
 
-    def test_no_capability_default_falls_back_to_framework_50(self) -> None:
-        assert resolve_max_turns(None, None, None) == DEFAULT_MAX_TURNS == 50
+    def test_capabilities_default_below_engine_default_wins_on_task_unset(self) -> None:
+        # Locks that the capability slot is a VALUE default, not a floor over
+        # DEFAULT_MAX_TURNS — a future refactor that silently changed
+        # `base = max(cap_default, DEFAULT_MAX_TURNS)` would fail here.
+        assert resolve_max_turns(None, None, 20) == 20
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_conductor.py
+++ b/tests/unit/test_conductor.py
@@ -356,6 +356,21 @@ class TestResolveMaxTurns:
     def test_tighter_of_two_set_values_wins(self) -> None:
         assert resolve_max_turns(100, 200) == 100
 
+    def test_capability_default_used_when_task_and_run_cap_none(self) -> None:
+        assert resolve_max_turns(None, None, 90) == 90
+
+    def test_run_cap_still_ceilings_capabilities_default(self) -> None:
+        assert resolve_max_turns(None, 60, 90) == 60
+
+    def test_task_explicit_wins_over_capability_default(self) -> None:
+        assert resolve_max_turns(45, None, 90) == 45
+
+    def test_task_and_run_both_still_min(self) -> None:
+        assert resolve_max_turns(45, 60, 90) == 45
+
+    def test_no_capability_default_falls_back_to_framework_50(self) -> None:
+        assert resolve_max_turns(None, None, None) == DEFAULT_MAX_TURNS == 50
+
 
 # ---------------------------------------------------------------------------
 # The trial's two tool surfaces
@@ -415,6 +430,7 @@ class TestTrialToolSurfacePartition:
         agent_client = MagicMock()
         agent_client.config = ModelConfig(provider="openai", name="gpt-4")
         agent_client.capabilities.schema_sanitizer.sanitize.side_effect = lambda s: s
+        agent_client.capabilities.default_max_turns = None
 
         return InProcessConductor(
             adapter=adapter,

--- a/tests/unit/test_gemini_preset_routing.py
+++ b/tests/unit/test_gemini_preset_routing.py
@@ -1,14 +1,23 @@
-"""Unit guard for the ``gemini`` preset's match-glob routing.
+"""Unit guard for the ``gemini`` preset family's match-glob routing.
 
 Asserts every Google Gemini model identifier under integration-test
-coverage is routed through the named ``gemini`` preset rather than
-falling through to ``default``.
+coverage is routed through the named preset that owns it:
 
-The first-match-wins discipline matters here: the ``gemini:`` block
-must sit AFTER any preset whose match globs could shadow it. None
-exist today (no other preset matches ``google/*`` or ``*gemini*``),
-but if a future preset is added with overlapping globs, this test
-catches the silent reroute.
+* ``gemini_31_pro_preview`` — the model-specific overlay for
+  ``google/gemini-3.1-pro-preview`` (and its OpenRouter-prefixed
+  variant). Carries the generic ``gemini`` policy trio verbatim plus
+  ``default_max_turns: 90``. Exact-match globs only.
+* ``gemini_35_flash_recursive`` / ``gemini_36_flash_recursive`` /
+  ``gemini_37_flash_recursive`` — Flash-lineage overlays for the
+  recursive-schema fix. Exact-match globs only.
+* ``gemini`` — the generic fallback that captures every other Gemini
+  identifier (family globs).
+
+The first-match-wins discipline matters here: each model-specific
+overlay must sit BEFORE the generic ``gemini:`` block, and the
+generic block must sit AFTER any preset whose match globs could
+shadow it. If a future preset is added with overlapping globs, this
+test catches the silent reroute.
 """
 
 from __future__ import annotations
@@ -23,7 +32,6 @@ pytestmark = pytest.mark.canonical
 _GEMINI_MODELS = (
     # Both variants under live integration test (see registry.py).
     "google/gemini-3-flash-preview",
-    "google/gemini-3.1-pro-preview",
     # Older family members — the preset must capture them too so we
     # don't leave stale fallthrough on existing eval configs.
     "google/gemini-3.0-flash",
@@ -32,6 +40,12 @@ _GEMINI_MODELS = (
     "google/gemini-2.5-flash",
     # OpenRouter-flavoured prefix (litellm sometimes sees the doubled form).
     "openrouter/google/gemini-3-flash-preview",
+)
+
+
+_GEMINI_31_PRO_PREVIEW_MODELS = (
+    "google/gemini-3.1-pro-preview",
+    "openrouter/google/gemini-3.1-pro-preview",
 )
 
 
@@ -44,6 +58,22 @@ def test_gemini_models_route_to_gemini_preset(model: str) -> None:
         "If a new preset was added with overlapping match globs, restore "
         "first-match-wins by moving the ``gemini:`` block earlier in "
         "model_presets.yaml."
+    )
+
+
+@pytest.mark.parametrize("model", _GEMINI_31_PRO_PREVIEW_MODELS)
+def test_gemini_31_pro_preview_routes_to_dedicated_preset(model: str) -> None:
+    """The exact ``google/gemini-3.1-pro-preview`` slug (bundled and
+    OpenRouter-prefixed) resolves to the dedicated overlay, not the
+    generic ``gemini`` preset. The overlay sits BEFORE the generic block
+    in ``model_presets.yaml`` so first-match-wins picks it up.
+    """
+    name = resolve_effective_preset(model, "openrouter")
+    assert name == "gemini_31_pro_preview", (
+        f"Expected {model!r} to route to 'gemini_31_pro_preview' preset, "
+        f"got {name!r}. Restore first-match-wins by keeping the "
+        "``gemini_31_pro_preview:`` block BEFORE the generic ``gemini:`` "
+        "block in model_presets.yaml."
     )
 
 

--- a/tests/unit/test_rate_limit_probe_wiring.py
+++ b/tests/unit/test_rate_limit_probe_wiring.py
@@ -308,12 +308,14 @@ class TestTheOvershootIsPartOfTheInvariant:
         config = _run_config(probe=probe)
         assert config.orchestrator.rate_limit_probe.turn_wall_ceiling_s < 14400
 
+        agent_client = MagicMock()
+        agent_client.capabilities.default_max_turns = None
         conductor = InProcessConductor(
             adapter=MagicMock(),
             artifact_writer=MagicMock(),
             config=config,
             logger=get_logger("probe-overshoot", strict=False),
-            agent_client=MagicMock(),
+            agent_client=agent_client,
             runtime_backend=MagicMock(),
             trial_grader=MagicMock(),
             output_dir=tmp_path,
@@ -339,12 +341,14 @@ class TestBudgetInvariantAgainstTheEffectiveTimeout:
     """The conductor re-checks after ``min(task.trial_seconds, run episode_s)``."""
 
     def _conductor(self, config: RunConfig, tmp_path: Path) -> InProcessConductor:
+        agent_client = MagicMock()
+        agent_client.capabilities.default_max_turns = None
         return InProcessConductor(
             adapter=MagicMock(),
             artifact_writer=MagicMock(),
             config=config,
             logger=get_logger("probe-wiring", strict=False),
-            agent_client=MagicMock(),
+            agent_client=agent_client,
             runtime_backend=MagicMock(),
             trial_grader=MagicMock(),
             output_dir=tmp_path,

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -86,22 +86,40 @@ __all__ = [
 DEFAULT_MAX_TURNS = 50
 
 
-def resolve_max_turns(task_max_turns: int | None, run_cap: int | None) -> int:
-    """Coalesce the task-declared budget and the optional run-level cap into a
-    concrete per-trial turn budget.
+def resolve_max_turns(
+    task_max_turns: int | None,
+    run_cap: int | None,
+    capabilities_default_max_turns: int | None = None,
+) -> int:
+    """Coalesce the task-declared budget, the operator's run-level cap, and the
+    preset-level per-model default into a concrete per-trial turn budget.
 
-    The run cap is an optional operator-side clamp; the task value is
-    authoritative for the task's own semantics. When both are set the effective
-    budget is the tighter of the two. When neither is set the engine default
-    (:data:`DEFAULT_MAX_TURNS`) applies.
+    Precedence:
+
+    * When the task pinned :attr:`TaskConfig.max_turns`, that value is
+      authoritative for the task's own semantics; the operator's ``run_cap``
+      still ceilings it (returns the tighter of the two).
+    * When the task did not pin its own budget, the base value is
+      ``capabilities_default_max_turns`` when set, otherwise the engine-wide
+      fallback :data:`DEFAULT_MAX_TURNS`. The operator's ``run_cap`` still
+      ceilings that base value.
+
+    ``capabilities_default_max_turns`` is threaded from
+    :attr:`ModelCapabilities.default_max_turns` — a preset-level value default
+    that fills the gap when neither the task nor the run config declared one.
     """
-    if task_max_turns is None and run_cap is None:
-        return DEFAULT_MAX_TURNS
-    if task_max_turns is None:
-        return run_cap
+    if task_max_turns is not None:
+        if run_cap is None:
+            return task_max_turns
+        return min(task_max_turns, run_cap)
+    base = (
+        capabilities_default_max_turns
+        if capabilities_default_max_turns is not None
+        else DEFAULT_MAX_TURNS
+    )
     if run_cap is None:
-        return task_max_turns
-    return min(task_max_turns, run_cap)
+        return base
+    return min(base, run_cap)
 
 
 # ---------------------------------------------------------------------------
@@ -729,7 +747,11 @@ class InProcessConductor:
 
         system_prompt = self._build_system_prompt(task, setup.tool_schemas, setup.task_dir)
 
-        max_turns = resolve_max_turns(task.max_turns, self.config.orchestrator.max_turns)
+        max_turns = resolve_max_turns(
+            task.max_turns,
+            self.config.orchestrator.max_turns,
+            self.agent_client.capabilities.default_max_turns,
+        )
 
         # Scale turn budget for complex multi-app mobile tasks only when task max_turns
         # is not explicitly pinned.

--- a/tolokaforge/core/llm/capabilities.py
+++ b/tolokaforge/core/llm/capabilities.py
@@ -141,6 +141,22 @@ class ModelCapabilities:
     (the default) leaves every tool message threaded through verbatim.
     """
 
+    default_max_turns: int | None = None
+    """Preset-level default for the per-trial turn budget when the task
+    did not declare its own ``TaskConfig.max_turns``.
+
+    Different models converge in different numbers of steps on the same
+    task — a coarser-grained model completes in fewer turns than one whose
+    per-turn edit style is more granular. This slot fills the gap when
+    neither the task nor the operator's run config set a budget: the
+    conductor's ``resolve_max_turns`` reads it as the value default before
+    the engine-wide fallback ``DEFAULT_MAX_TURNS = 50`` applies.
+    ``TaskConfig.max_turns`` still wins when set, and
+    ``OrchestratorConfig.max_turns`` still ceilings the resolved value.
+    ``None`` (the default) leaves the engine-wide fallback in place — every
+    preset that does not name the key inherits it.
+    """
+
     openrouter_defaults: OpenRouterConfig | None = None
     """Preset-level default for :attr:`ModelConfig.openrouter`.
 

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -1052,6 +1052,7 @@ def build_capabilities(
     api_call_wall_timeout_s = cfg.get("api_call_wall_timeout_s")
     empty_retry_count = cfg.get("empty_retry_count")
     tool_output_max_chars = cfg.get("tool_output_max_chars")
+    default_max_turns = cfg.get("default_max_turns")
     openrouter_defaults_cfg = cfg.get("openrouter_defaults")
 
     return ModelCapabilities(
@@ -1073,6 +1074,7 @@ def build_capabilities(
         tool_output_max_chars=(
             int(tool_output_max_chars) if tool_output_max_chars is not None else None
         ),
+        default_max_turns=(int(default_max_turns) if default_max_turns is not None else None),
         openrouter_defaults=(
             OpenRouterConfig(**openrouter_defaults_cfg) if openrouter_defaults_cfg else None
         ),

--- a/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
+++ b/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
@@ -717,6 +717,39 @@ presets:
     schema_sanitizer: gemini_recursive
     response_policy: scalar_array_dict_map
 
+  # Gemini 3.1 Pro Preview — model-specific overlay carrying the generic
+  # ``gemini`` policy trio (reasoning_codec + schema_sanitizer +
+  # response_policy) PLUS one Pro-observed turn-budget default the shared
+  # preset does not carry. Different models converge in different numbers
+  # of steps on the same task; a Pro-lineage per-turn edit style is more
+  # granular than the framework baseline, so the same absolute budget
+  # exhausts earlier on tasks a coarser-grained model completes in fewer
+  # turns. Live evidence: 8/8 gemini-3.1-pro-preview T-Bench balanced-10
+  # failures on the 2026-09-04 head-to-head hit
+  # ``termination_reason: max_turns`` at exactly turn 60 with trajectories
+  # mid-productive at the cutoff. 90 is the conservative lift over the
+  # 50-turn engine default (issue #1493's suggested lower bound);
+  # operators raise it further via preset overlay when observed
+  # convergence warrants it.
+  #
+  # ``TaskConfig.max_turns`` still wins for tasks that pin their own
+  # budget (the loop-cap authority the task author declared).
+  # ``OrchestratorConfig.max_turns`` still ceilings the resolved value
+  # (the operator's clamp). This default only fills in on the
+  # task-unset + run-cap-unset-or-above-90 path.
+  #
+  # Exact match globs only, listed BEFORE the generic ``gemini`` glob so
+  # no sibling Gemini route (2.5, 3-flash, 3.5-flash, 3.6-flash, 3.7-flash)
+  # inherits the bump.
+  gemini_31_pro_preview:
+    match:
+      - "google/gemini-3.1-pro-preview"
+      - "openrouter/google/gemini-3.1-pro-preview"
+    reasoning_codec: gemini
+    schema_sanitizer: gemini
+    response_policy: array_dict_map
+    default_max_turns: 90
+
   # Google Gemini family (3.x preview + 3.x GA + 2.5 backstop).
   # ``GeminiReasoningCodec`` decodes Gemini's OpenRouter
   # ``provider_specific_fields.reasoning_details`` envelope: handles

--- a/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
+++ b/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
@@ -728,7 +728,7 @@ presets:
   # failures on the 2026-09-04 head-to-head hit
   # ``termination_reason: max_turns`` at exactly turn 60 with trajectories
   # mid-productive at the cutoff. 90 is the conservative lift over the
-  # 50-turn engine default (issue #1493's suggested lower bound);
+  # 50-turn engine default;
   # operators raise it further via preset overlay when observed
   # convergence warrants it.
   #


### PR DESCRIPTION
## Summary

- Add `ModelCapabilities.default_max_turns: int | None = None` — an optional per-model default turn budget on the frozen dataclass, sibling to the existing `empty_retry_count` / `tool_output_max_chars` numeric-knob row.
- Extend `conductor.resolve_max_turns(task_max_turns, run_cap, capabilities_default_max_turns=None)` with a third positional-with-default arg. Precedence chain: task explicit → capabilities_default → framework 50, all ceilinged by an operator-set `orchestrator.max_turns` when present.
- Opt in a new `gemini_31_pro_preview` preset at `default_max_turns: 90`, placed before the generic `gemini:` block. Match globs are exact (`google/gemini-3.1-pro-preview` and `openrouter/google/gemini-3.1-pro-preview`); adjacent Gemini slugs (`-customtools`, Flash, 3.0, 2.5) fall through to the generic preset by design.

## Design choices

- **This is an engine-loop generalisation, not a per-model workaround.** Different models converge in different numbers of steps on the same task — a per-turn edit style that spreads work across finer-grained tool calls exhausts the same absolute budget earlier than one that batches. A single global `DEFAULT_MAX_TURNS = 50` in the framework cannot fit every model at every task-set. Extending the type-system table's numeric-knob row of `ModelCapabilities` with a per-model default is the natural completion of the existing pattern — future models can opt in without engine-code changes.
- **Task-explicit values win over capability defaults.** Task authors have specific knowledge about their trajectory shape; the capability default is a fallback for unopinionated tasks. Reversing this would silently override task-authored budgets and break existing per-task calibration.
- **Operator cap (`orchestrator.max_turns`) continues to ceiling everything.** The plan's chosen semantic preserves compat with every existing run config; the alternative (capability default overrides operator cap) would silently invalidate operator-side calibration on existing evals. Follow-ups #1506 (flip `OrchestratorConfig.max_turns` default from 50 to `None`) and #1507 (raise eval-config caps to match the observed per-model needs) are filed as separate scope; this PR ships the general-harness change, not the config-side application.
- **New preset restates the full policy trio.** Following the sibling `gemini_35/36/37_flash_recursive` overlays, the new `gemini_31_pro_preview` preset re-declares `reasoning_codec`, `schema_sanitizer`, and `response_policy` verbatim from the generic `gemini:` block so a future edit to either side doesn't create silent policy drift.

## Concepts introduced

- **`ModelCapabilities.default_max_turns: int | None = None`** — new numeric-knob slot on the frozen dataclass. `None` (default) preserves current behaviour: `resolve_max_turns` falls back to `DEFAULT_MAX_TURNS`. Value default, not floor — a preset can opt in at 20 and get 20 (locked by `test_capabilities_default_below_engine_default_wins_on_task_unset`).
- **`resolve_max_turns` third arg** — positional-with-default so every existing 2-arg call site keeps its exact behaviour bit-for-bit. Precedence: task explicit → capability default → `DEFAULT_MAX_TURNS`, ceilinged by `run_cap` when set.
- **`gemini_31_pro_preview` preset** — first per-model opt-in at 90 turns. Preset comment cites the 2026-09-04 T-Bench balanced-10 observation (8/8 failures at exactly turn 60 with mid-productive trajectories) as the general observation — Gemini Pro Preview's per-turn edit style exhausts the framework default earlier than the average model, and 90 is a conservative lift.

## Plan

See `~/.claude/plans/toloka-tolokaforge/issue-1493-per-model-max-turns.md`. Four commits:

1. `eba34dee feat(engine-loop): add ModelCapabilities.default_max_turns slot + preset pass-through` — Stage 1. Additive slot on `ModelCapabilities` + `build_capabilities` read-through + baseline canonical routing test (`tests/canonical/test_default_max_turns_preset_routing.py`) parametrising 12 tracked slugs and locking `default_max_turns is None` on every one.

2. `b14d2dae feat(engine-loop): resolve_max_turns consumes ModelCapabilities.default_max_turns` — Stage 2. `resolve_max_turns` extended with a third positional-with-default arg + conductor call site threads `self.agent_client.capabilities.default_max_turns` through + 5 new precedence unit tests in `test_conductor.py::TestResolveMaxTurns` + `docs/LLM_LAYER.md § "Per-model turn-budget default"` new subsection. Also fixes 2 MagicMock-stub gaps in `test_conductor.py::TestTrialToolSurfacePartition` and `test_rate_limit_probe_wiring.py` where the new capability read would have hit `TypeError`.

3. `b56176fb feat(engine-loop): gemini_31_pro_preview preset opts in at default_max_turns=90` — Stage 3. New preset before generic `gemini:` block + `tests/unit/test_gemini_preset_routing.py` regression guard update (moves the slug out of `_GEMINI_MODELS` and adds positive assertions on the new preset name for both bundled and `openrouter/`-prefixed variants) + canonical opt-in assertion in the Stage 1 routing test file + `docs/LLM_LAYER.md § "Per-model turn-budget default"` extension. Also fixes a third MagicMock-stub gap in `test_terminal_bench_harness_mode.py` surfaced by the broader canonical sweep.

4. `255436ee chore(hygiene): strip issue-attribution parentheticals from preset + test docstring` — hygiene reviewer R1 fix. Two `(issue #1493's suggested lower bound)` parentheticals removed per §7a (git blame is the authoritative attribution channel). Zero behaviour changes.

5. `18c58a96 test(conductor): fold redundant + lock value-vs-floor semantic on resolve_max_turns` — correctness reviewer fix. Folded a redundant test (semantically identical to a pre-existing 2-arg test) into the existing test as an explicit-None assertion, and added `test_capabilities_default_below_engine_default_wins_on_task_unset` locking that the slot is a value default, not a floor over `DEFAULT_MAX_TURNS`.

## Discovered issues

- **Filed** (during architect discovery): #1506 (flip `OrchestratorConfig.max_turns` default from 50 to `None`) and #1507 (head-to-head eval configs pin `orchestrator.max_turns` to the effective per-model cap). Both filed as `enhancement` follow-ups — this PR ships the additive slot; #1506 or #1507 make it observably effective on evals that currently pin the operator cap tight.
- **Fixed in this PR**: three MagicMock stubs (`test_conductor.py::TestTrialToolSurfacePartition`, `test_rate_limit_probe_wiring.py`, `test_terminal_bench_harness_mode.py`) needed `capabilities.default_max_turns = None` and (in one file) `orchestrator.max_turns = None` explicit pins — same class of stub-gap #1491 and #1495 handled in-scope under the "broken code found = broken code fixed" rule.

## Test plan

- `pytest tests/unit/test_conductor.py::TestResolveMaxTurns -v` — 12 passed (7 pre-existing + 5 new, including the value-vs-floor lock).
- `pytest tests/canonical/test_default_max_turns_preset_routing.py -v` — 13 passed (11 must-stay-None + 2 opt-in).
- `pytest tests/unit/test_gemini_preset_routing.py -v` — regression guard green under the new preset.
- `pytest tests/canonical/ -m canonical --deselect tests/canonical/test_harness_registry_replay.py::test_replay_matches_baseline -q` — 1955 passed, 18 skipped (pre-existing `test_replay_matches_baseline` failure on unrelated baseline drift, tracked as #1234).
- `pytest tests/unit/llm/ tests/unit/test_tool_calling_loop.py tests/unit/test_runner_logic.py tests/unit/test_conductor.py -q` — regression sweep 978 passed.
- `ruff check` + `black --check` + `ruff format --check` on all touched files: clean.
- Pre-commit hooks (ruff, black, import-boundary contracts): all passed.

Closes #1493.