### PR TITLE
feat(engine-loop): output-length retry-with-feedback seam

### DIFF
--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -1860,10 +1860,10 @@ content-carrying gate.
 preset opts in today; canonical
 [`tests/canonical/test_output_length_retry_count_preset_routing.py`](../tests/canonical/test_output_length_retry_count_preset_routing.py)
 enumerates every currently-registered preset and pins the default. An
-observed-evidence opt-in for a specific preset lands in a follow-up PR
-with the per-workload truncation rate recorded in the preset comment
-(the discipline `empty_retry_count`'s `moonshot_kimi_k3` /
-`anthropic_claude_opus_5` opt-ins follow).
+observed-evidence opt-in for a specific preset requires the per-workload
+truncation rate recorded in the preset comment (matching the discipline
+`empty_retry_count`'s `moonshot_kimi_k3` / `anthropic_claude_opus_5`
+opt-ins use).
 
 ### Context-window handoff
 

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -1803,6 +1803,68 @@ directly rather than routing it through `classify_loop_error` so post-run
 analysis can tell "the model produced nothing" apart from the API-error
 class that would otherwise absorb it.
 
+### Output-length retry
+
+A generation that comes back with content and `finish_reason == "length"`
+is a *max-tokens truncation*: the model produced tokens but the provider
+cut the response at its output budget. `ToolCallingLoop._run_turn` reads
+this signal directly from `GenerationResult.finish_reason` — sourced in
+`_assemble_result` from `choice.finish_reason`, which litellm post-maps
+every current provider's max-tokens reason (native OpenAI `"length"`,
+Gemini `MAX_TOKENS`, Anthropic `max_tokens`) to the OpenAI-compatible
+string `"length"`. When `capabilities.output_length_retry_count > 0`, the
+loop discards the truncated response, appends a `role=user` feedback turn
+advising the model that its previous reply was truncated at `max_tokens`
+and asking it to split the next action into smaller pieces, and resamples
+without appending the truncated assistant message and without advancing
+the outer turn counter. On budget exhaustion the loop falls through to
+accept-and-continue — the last (still-truncated) response lands as the
+assistant turn and the trial continues — so the seam is strictly
+recoverable and never a new terminal reason. The metrics sink records
+every resampled generation because the trial paid for each call. The
+default `output_length_retry_count = 0` accepts the truncated response
+as the assistant turn unchanged — the seam is opt-in per preset.
+
+The feedback turn is `MessageRole.USER` — not `MessageRole.SYSTEM` — and
+this is load-bearing. Every other inline marker `_run_turn` inserts via
+`_append_both` (the empty-completion terminal message, the
+`TerminationDecision` system message, the summarize marker, the
+`MAX_TURNS` marker) either terminates the loop or advances the outer
+turn, so litellm's Anthropic-adapter convention of hoisting an inline
+`role=system` message into the top-level `system` parameter of the next
+request is inert for them. The output-length retry is the first
+`_run_turn` path that inserts a marker *and continues the loop*, so a
+`role=system` feedback turn here would be hoisted into the initial
+system prompt on the resample rather than landing mid-conversation —
+defeating the seam's intent. The `role=user` shape stays positional on
+every adapter and mirrors the tool-response pattern that is already
+provider-safe on Anthropic / OpenAI / Gemini / Bedrock. A future edit
+that reshapes the feedback turn "for consistency" with the other markers
+must preserve this constraint or move all four seams onto a shared
+positional shape.
+
+Orthogonal to `empty_retry_count` (which fires on empty-shape results
+with no content and terminates on exhaustion) and to the loop-level
+API-error retry (which replays a raised exception). Each retry class
+owns a distinct trigger — content-carrying truncation, empty-shape
+completion, raised transient exception — and a dedicated `LoopConfig`
+field so a preset can tune them independently. The strictly-empty branch
+of `_run_turn` still handles a `finish_reason == "length"` result whose
+content is empty (reasoning-budget exhaustion) via `empty_retry_count`,
+because the output-length branch nests *inside* the outer
+content-carrying gate.
+
+`LoopConfig.output_length_retry_count` flows from
+`capabilities.output_length_retry_count` at
+[`runner.py`](../tolokaforge/core/runner.py) construction time. No
+preset opts in today; canonical
+[`tests/canonical/test_output_length_retry_count_preset_routing.py`](../tests/canonical/test_output_length_retry_count_preset_routing.py)
+enumerates every currently-registered preset and pins the default. An
+observed-evidence opt-in for a specific preset lands in a follow-up PR
+with the per-workload truncation rate recorded in the preset comment
+(the discipline `empty_retry_count`'s `moonshot_kimi_k3` /
+`anthropic_claude_opus_5` opt-ins follow).
+
 ### Context-window handoff
 
 `ModelCapabilities.max_context_tokens: int | None` and
@@ -2443,13 +2505,18 @@ outer controllers above, transport-timeout retry in
 protocol. Retrying them at the loop level would double-count the exclusion and
 confuse the denominator.
 
-The empty-completion retry is a separate class that lives in
-`_run_turn` under its own budget on `LoopConfig.empty_retry_count`. The two
-retry classes are orthogonal: the API-error retry replays a *raised
-exception*, and the empty-completion retry resamples a *returned empty-shape
-result* (see § *Provider-side empty completion* above for the resample
-mechanics and the Gemini-legal-tail invariant). Each owns a dedicated
-`LoopConfig` field so a preset can tune them independently.
+The empty-completion retry and the output-length retry are two separate
+classes that live in `_run_turn`, each under its own budget on
+`LoopConfig.empty_retry_count` and `LoopConfig.output_length_retry_count`.
+The three retry classes are orthogonal — each fires on a distinct
+trigger: the API-error retry replays a *raised exception*, the
+empty-completion retry resamples a *returned empty-shape result* (see §
+*Provider-side empty completion* above for the resample mechanics and
+the Gemini-legal-tail invariant), and the output-length retry appends a
+`role=user` feedback turn and resamples a *returned content-carrying
+truncation* under its own budget before falling through to
+accept-and-continue (see § *Output-length retry* above). Each owns a
+dedicated `LoopConfig` field so a preset can tune them independently.
 
 `TerminationReason.CONTEXT_WINDOW_EXCEEDED` is a third wire-shape reason
 (parallel to `EMPTY_COMPLETION`), not routed through the API-error retry.

--- a/tests/canonical/test_output_length_retry_count_preset_routing.py
+++ b/tests/canonical/test_output_length_retry_count_preset_routing.py
@@ -1,0 +1,48 @@
+"""Canonical test — preset → ``output_length_retry_count`` routing.
+
+Every currently-registered preset resolves to the default
+``output_length_retry_count == 0``. The seam is available; no preset opts
+in on this PR because the opt-in doubles reasoning spend on the failing
+sample and lives on per-model + per-workload observed evidence that does
+not yet exist for the visible-truncation shape.
+
+An unintentional preset opt-in fails this test. The right move on a
+failure is to remove the offending overlay entry, not to mute the
+assertion — a follow-up PR opts a preset in with the observed evidence
+recorded in the preset comment (the discipline
+``test_empty_retry_count_preset_routing.py`` establishes for the sibling
+retry class).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.llm import build_capabilities
+
+pytestmark = pytest.mark.canonical
+
+
+_OUTPUT_LENGTH_RETRY_ZERO_MODELS = [
+    ("openai/gpt-4o", "openrouter"),
+    ("anthropic/claude-opus-4.7", "openrouter"),
+    ("anthropic/claude-sonnet-4.7", "openrouter"),
+    ("openai/gpt-5.5", "openrouter"),
+    ("x-ai/grok-4", "openrouter"),
+    ("qwen/qwen3-coder", "openrouter"),
+    ("google/gemini-3.1-pro-preview", "openrouter"),
+    ("moonshotai/kimi-k3", "openrouter"),
+    ("moonshotai/kimi-k2.6", "openrouter"),
+    ("claude-opus-5", "anthropic"),
+]
+
+
+@pytest.mark.parametrize(("model", "provider"), _OUTPUT_LENGTH_RETRY_ZERO_MODELS)
+def test_preset_leaves_output_length_retry_count_zero(model: str, provider: str) -> None:
+    caps = build_capabilities(model, provider)
+    assert caps.output_length_retry_count == 0, (
+        f"{model!r} must resolve to output_length_retry_count=0. The engine "
+        "seam is available but no preset opts in on this PR; opt-ins land "
+        "in a follow-up with observed evidence recorded in the preset "
+        f"comment. Got: {caps.output_length_retry_count}."
+    )

--- a/tests/canonical/test_output_length_retry_count_preset_routing.py
+++ b/tests/canonical/test_output_length_retry_count_preset_routing.py
@@ -1,17 +1,15 @@
 """Canonical test — preset → ``output_length_retry_count`` routing.
 
 Every currently-registered preset resolves to the default
-``output_length_retry_count == 0``. The seam is available; no preset opts
-in on this PR because the opt-in doubles reasoning spend on the failing
-sample and lives on per-model + per-workload observed evidence that does
-not yet exist for the visible-truncation shape.
+``output_length_retry_count == 0``. Opting a preset in requires per-model
++ per-workload observed evidence for the visible-truncation shape, recorded
+in the preset comment; the opt-in doubles reasoning spend on the failing
+sample, so a blanket enable is inappropriate.
 
 An unintentional preset opt-in fails this test. The right move on a
 failure is to remove the offending overlay entry, not to mute the
-assertion — a follow-up PR opts a preset in with the observed evidence
-recorded in the preset comment (the discipline
-``test_empty_retry_count_preset_routing.py`` establishes for the sibling
-retry class).
+assertion — matching the discipline ``test_empty_retry_count_preset_routing.py``
+establishes for the sibling retry class.
 """
 
 from __future__ import annotations
@@ -41,8 +39,8 @@ _OUTPUT_LENGTH_RETRY_ZERO_MODELS = [
 def test_preset_leaves_output_length_retry_count_zero(model: str, provider: str) -> None:
     caps = build_capabilities(model, provider)
     assert caps.output_length_retry_count == 0, (
-        f"{model!r} must resolve to output_length_retry_count=0. The engine "
-        "seam is available but no preset opts in on this PR; opt-ins land "
-        "in a follow-up with observed evidence recorded in the preset "
-        f"comment. Got: {caps.output_length_retry_count}."
+        f"{model!r} must resolve to output_length_retry_count=0. Opt-ins "
+        "require per-workload truncation-rate evidence recorded in the "
+        "preset comment; if you intended to opt this preset in, add the "
+        f"evidence there rather than mute this assertion. Got: {caps.output_length_retry_count}."
     )

--- a/tests/unit/llm/test_generation_result_finish_reason.py
+++ b/tests/unit/llm/test_generation_result_finish_reason.py
@@ -1,0 +1,75 @@
+"""``GenerationResult.finish_reason`` ingestion contract.
+
+Pins that :meth:`LLMClient._assemble_result` sources
+:attr:`GenerationResult.finish_reason` from the litellm-post-mapped
+``choice.finish_reason`` verbatim — the OpenAI-compatible signal that
+every provider litellm supports today post-maps its max-tokens truncation
+to (``"length"``). This is the wire-shape observation the engine loop's
+output-length retry seam reads: a false-negative (dropping ``"length"``
+during parse) would silently disable the seam for opted-in presets.
+
+Uses the ``MagicMock`` / ``patch`` idiom already established in
+:mod:`tests.unit.llm.test_synthetic_envelope_detection`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tolokaforge.core.llm.client import LLMClient
+from tolokaforge.core.models import Message, MessageRole, ModelConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _response(finish_reason: str, content: str = "hello") -> MagicMock:
+    """Build a minimal litellm-shape response carrying ``finish_reason``."""
+    response = MagicMock()
+    choice = MagicMock()
+    message = MagicMock()
+    message.content = content
+    message.tool_calls = None
+    message.thinking_blocks = None
+    message.reasoning_content = None
+    message.provider_specific_fields = None
+    choice.message = message
+    choice.finish_reason = finish_reason
+    choice.provider_specific_fields = None
+    response.choices = [choice]
+    response.usage = MagicMock(
+        prompt_tokens=1,
+        completion_tokens=1,
+        total_tokens=2,
+        prompt_tokens_details=None,
+        completion_tokens_details=None,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    )
+    return response
+
+
+def _make_client(monkeypatch: pytest.MonkeyPatch) -> LLMClient:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-sk-finish-reason")
+    client = LLMClient(ModelConfig(provider="openrouter", name="openai/gpt-4o"))
+    client._retry_sleep = lambda _s: None
+    return client
+
+
+@pytest.mark.parametrize("finish_reason", ["stop", "length"])
+def test_finish_reason_roundtrips_from_choice(
+    monkeypatch: pytest.MonkeyPatch, finish_reason: str
+) -> None:
+    """``choice.finish_reason`` reaches ``GenerationResult.finish_reason``
+    verbatim for both a clean stop and a max-tokens truncation. If parse
+    drops the field, the engine's output-length seam goes silent."""
+    client = _make_client(monkeypatch)
+    response = _response(finish_reason)
+    with patch("tolokaforge.core.llm.client.completion", return_value=response):
+        with patch("tolokaforge.core.llm.client.estimate_cost", return_value=0.0):
+            result = client.generate(
+                system="s",
+                messages=[Message(role=MessageRole.USER, content="hi")],
+            )
+    assert result.finish_reason == finish_reason

--- a/tests/unit/test_tool_calling_loop.py
+++ b/tests/unit/test_tool_calling_loop.py
@@ -40,14 +40,20 @@ class _ScriptedClient:
 
     An entry that is an ``Exception`` instance is raised on that call instead —
     the retry-loop tests script provider failures this way.
+
+    ``messages_history`` snapshots the wire ``messages`` argument on each call
+    so a test can pin what actually reached the provider on the second call
+    (a copy is taken because the loop mutates the underlying list in place).
     """
 
     def __init__(self, results: list[GenerationResult | Exception]) -> None:
         self._results = list(results)
         self.calls = 0
+        self.messages_history: list[list[Message]] = []
 
     def generate(self, system, messages, tools, tool_choice="auto", observation=None):
         self.calls += 1
+        self.messages_history.append(list(messages))
         item = self._results.pop(0)
         if isinstance(item, Exception):
             raise item
@@ -617,6 +623,197 @@ def test_empty_completion_retry_does_not_advance_turn_counter():
             max_turns=1,
             episode_timeout_s=10_000,
             empty_retry_count=2,
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 3
+    assert executor.executed == [("query", {"q": 1}, "a")]
+    assert outcome.termination_reason == TerminationReason.MAX_TURNS
+
+
+def test_length_truncated_completion_not_retried_when_opt_out():
+    """With ``output_length_retry_count=0`` (the default) a content-carrying
+    result with ``finish_reason="length"`` lands as the assistant turn
+    unchanged and the loop advances. No feedback marker is inserted — this
+    locks the default-off invariant against silent drift into a global
+    retry-with-feedback default (which would double reasoning spend on every
+    truncation across every preset)."""
+    client = _ScriptedClient(
+        [
+            GenerationResult(
+                text="partial",
+                usage=Usage(prompt_tokens=3),
+                finish_reason="length",
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        max_turns=1,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            output_length_retry_count=0,
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 1
+    assistant_messages = [m for m in messages if m.role == MessageRole.ASSISTANT]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].content == "partial"
+    assert not any(
+        m.role == MessageRole.USER and "truncated at max_tokens" in (m.content or "")
+        for m in messages
+    )
+    assert outcome.termination_reason == TerminationReason.MAX_TURNS
+
+
+def test_length_truncated_completion_resamples_and_recovers():
+    """With ``output_length_retry_count=1`` the first truncated response is
+    discarded, a ``role=user`` truncation-feedback turn is appended to both
+    the recorded history and the wire history, and the second (untruncated)
+    sample lands as the assistant turn. Locks the recovery shape and pins
+    that the feedback actually reaches the wire on the retry call."""
+    client = _ScriptedClient(
+        [
+            GenerationResult(
+                text="partial",
+                usage=Usage(prompt_tokens=3),
+                finish_reason="length",
+            ),
+            GenerationResult(
+                text="recovered",
+                usage=Usage(prompt_tokens=5),
+                finish_reason="stop",
+            ),
+        ]
+    )
+    sink = _CountingSink()
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        sink=sink,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            output_length_retry_count=1,
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 2
+    # (c) both generations bill the metrics sink because the trial paid.
+    assert sink.generations == 2
+
+    # (a) exactly one user-feedback turn with the truncation phrasing.
+    feedback_turns = [
+        m
+        for m in messages
+        if m.role == MessageRole.USER and "truncated at max_tokens" in (m.content or "")
+    ]
+    assert len(feedback_turns) == 1
+
+    # (b) the truncated assistant message was NOT appended.
+    assert not any(m.role == MessageRole.ASSISTANT and m.content == "partial" for m in messages)
+    assistant_messages = [m for m in messages if m.role == MessageRole.ASSISTANT]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].content == "recovered"
+
+    # (d) wire-level lock: the SECOND generate call's messages list ends with
+    # the truncation-feedback user turn — the retry with feedback actually
+    # reaches the provider, not just the recorded trajectory.
+    second_call_messages = client.messages_history[1]
+    tail = second_call_messages[-1]
+    assert tail.role == MessageRole.USER
+    assert "truncated at max_tokens" in (tail.content or "")
+
+    assert outcome.termination_reason == TerminationReason.MAX_TURNS
+
+
+def test_length_truncated_completion_exhausts_and_accepts_last_response():
+    """With ``output_length_retry_count=1``, two consecutive truncated
+    responses exhaust the budget: exactly one feedback turn was inserted
+    (before the second attempt) and the second truncated response lands as
+    the assistant turn with its partial content preserved. The loop
+    continues normally — no new terminal, no ``EMPTY_COMPLETION`` — the
+    exhaustion path is strictly recoverable."""
+    client = _ScriptedClient(
+        [
+            GenerationResult(
+                text="partial-1",
+                usage=Usage(prompt_tokens=3),
+                finish_reason="length",
+            ),
+            GenerationResult(
+                text="partial-2",
+                usage=Usage(prompt_tokens=3),
+                finish_reason="length",
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            output_length_retry_count=1,
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 2
+    assert outcome.termination_reason == TerminationReason.MAX_TURNS
+    assert outcome.status == TrialStatus.COMPLETED
+    assistant_messages = [m for m in messages if m.role == MessageRole.ASSISTANT]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].content == "partial-2"
+    feedback_turns = [
+        m
+        for m in messages
+        if m.role == MessageRole.USER and "truncated at max_tokens" in (m.content or "")
+    ]
+    assert len(feedback_turns) == 1
+
+
+def test_length_retry_does_not_advance_turn_counter():
+    """Resamples happen within the same outer turn. With ``max_turns=1`` and
+    ``output_length_retry_count=2`` the loop absorbs two truncated resamples
+    on turn 0 and executes the recovered tool call also on turn 0, so a
+    single outer iteration consumes three generations. Mirrors the shape of
+    ``test_empty_completion_retry_does_not_advance_turn_counter``."""
+    executor = _RecordingExecutor()
+    client = _ScriptedClient(
+        [
+            GenerationResult(
+                text="partial-1",
+                usage=Usage(prompt_tokens=1),
+                finish_reason="length",
+            ),
+            GenerationResult(
+                text="partial-2",
+                usage=Usage(prompt_tokens=1),
+                finish_reason="length",
+            ),
+            GenerationResult(
+                text="ok",
+                tool_calls=[ToolCall(id="a", name="query", arguments={"q": 1})],
+                usage=Usage(prompt_tokens=5),
+                finish_reason="tool_calls",
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        executor=executor,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            output_length_retry_count=2,
         ),
     ).run("sys", messages, time.time())
 

--- a/tests/unit/test_tool_calling_loop.py
+++ b/tests/unit/test_tool_calling_loop.py
@@ -822,6 +822,41 @@ def test_length_retry_does_not_advance_turn_counter():
     assert outcome.termination_reason == TerminationReason.MAX_TURNS
 
 
+def test_length_finish_reason_with_empty_content_uses_empty_path():
+    """A ``finish_reason=='length'`` result with no text / no tool_calls
+    routes through the empty-completion branch, not the length-retry branch.
+    Locks the disjoint-path invariant against a future refactor that flattens
+    the current nesting under ``if result.text or result.tool_calls:``."""
+    client = _ScriptedClient(
+        [
+            GenerationResult(
+                text="",
+                usage=Usage(prompt_tokens=1),
+                finish_reason="length",
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            empty_retry_count=0,
+            output_length_retry_count=1,
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 1
+    assert outcome.termination_reason == TerminationReason.EMPTY_COMPLETION
+    # Length-retry did NOT fire — no user feedback marker was inserted.
+    assert not any(
+        m.role == MessageRole.USER and "truncated at max_tokens" in (m.content or "")
+        for m in messages
+    )
+
+
 def test_api_error_retry_budget_resets_per_outer_turn():
     """A successful turn 0 followed by an API-error turn 1 gets a fresh retry
     budget: the counter resets at the start of every outer iteration, so a

--- a/tolokaforge/core/llm/capabilities.py
+++ b/tolokaforge/core/llm/capabilities.py
@@ -126,6 +126,28 @@ class ModelCapabilities:
     every resampled generation because the trial paid for each call.
     """
 
+    output_length_retry_count: int = 0
+    """Resample budget for a content-carrying max-tokens truncation.
+
+    On a returned ``GenerationResult`` with content and
+    ``finish_reason == "length"`` (litellm's post-mapped value for a provider
+    that truncated the response at ``max_tokens``), the engine appends a
+    ``role=user`` feedback turn advising the model that its previous response
+    was cut off and asking it to split the next action into smaller pieces,
+    then resamples up to ``output_length_retry_count`` times without
+    appending the truncated assistant message and without advancing the outer
+    turn counter. On budget exhaustion the loop appends the last truncated
+    response as the assistant turn and continues — the seam is strictly
+    recoverable and never a new terminal reason.
+
+    Orthogonal to :attr:`empty_retry_count` (which fires on empty-shape
+    results with no content and terminates on exhaustion) and to the
+    loop-level API-error retry: each retry class owns a distinct trigger and
+    a dedicated budget. The default ``0`` accepts the truncated response as
+    the assistant turn unchanged. Metrics record every resampled generation
+    because the trial paid for each call.
+    """
+
     tool_output_max_chars: int | None = None
     """Loop-layer cap on the ``role=tool`` message content, in chars.
 

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -530,6 +530,7 @@ class GenerationResult:
         reasoning: StructuredReasoning | None = None,
         effective_system_prompt: str | None = None,
         openrouter_generation_id: str | None = None,
+        finish_reason: str | None = None,
     ):
         self.text = text
         self.tool_calls = tool_calls or []
@@ -548,6 +549,14 @@ class GenerationResult:
         # on ``usage.calls[-1]`` — carried here so the turn loop can stamp it
         # onto the assistant message without reaching into the usage record.
         self.openrouter_generation_id = openrouter_generation_id
+        # litellm's post-mapped ``choice.finish_reason`` (e.g. ``"stop"``,
+        # ``"length"``, ``"tool_calls"``). ``"length"`` on a content-carrying
+        # result means the provider truncated the response at ``max_tokens``
+        # — the engine loop's output-length retry seam reads it to decide
+        # whether to resample with feedback (see
+        # :attr:`ModelCapabilities.output_length_retry_count`). ``None`` when
+        # the response carries no finish_reason at all.
+        self.finish_reason = finish_reason
         # Defects of the attempts discarded before this reply was accepted.
         # Stamped only by ``UserSimulator._llm_reply``; every other producer
         # of a result leaves it empty.
@@ -2274,6 +2283,10 @@ class LLMClient:
             # that returned no usage block contributes no call record, and the
             # routing decision is still worth recording for that turn.
             openrouter_generation_id=extract_openrouter_generation_id(response),
+            # litellm post-maps every current provider's max-tokens truncation
+            # to the OpenAI-compatible ``"length"`` on this field; a response
+            # that carries no finish_reason at all lands as ``None``.
+            finish_reason=getattr(choice, "finish_reason", None),
         )
 
     # ------------------------------------------------------------------

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -1051,6 +1051,7 @@ def build_capabilities(
     api_call_retries = cfg.get("api_call_retries")
     api_call_wall_timeout_s = cfg.get("api_call_wall_timeout_s")
     empty_retry_count = cfg.get("empty_retry_count")
+    output_length_retry_count = cfg.get("output_length_retry_count")
     tool_output_max_chars = cfg.get("tool_output_max_chars")
     default_max_turns = cfg.get("default_max_turns")
     max_context_tokens = cfg.get("max_context_tokens")
@@ -1073,6 +1074,9 @@ def build_capabilities(
             float(api_call_wall_timeout_s) if api_call_wall_timeout_s is not None else None
         ),
         empty_retry_count=int(empty_retry_count) if empty_retry_count is not None else 0,
+        output_length_retry_count=(
+            int(output_length_retry_count) if output_length_retry_count is not None else 0
+        ),
         tool_output_max_chars=(
             int(tool_output_max_chars) if tool_output_max_chars is not None else None
         ),

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -116,13 +116,19 @@ class LoopConfig:
     retry that fires only on :attr:`TerminationReason.API_ERROR` — a transient
     provider fault the classifier could not attribute to a typed reason.
     ``empty_retry_count`` sets the resample budget for a returned empty
-    completion; the two retry classes are orthogonal — the API-error retry
-    replays a raised exception, and the empty-completion retry resamples a
-    returned empty-shape result without appending the empty assistant message
-    and without advancing the outer turn counter. ``RATE_LIMIT``,
-    ``API_TIMEOUT`` and ``TRIAL_LOST`` stay one-shot terminal because each owns
-    a dedicated path (typed 429 handling, transport-timeout retry, substrate
-    re-registration) and retrying them here would double-count them.
+    completion; ``output_length_retry_count`` sets the resample budget for a
+    content-carrying max-tokens truncation. The three retry classes are
+    orthogonal — the API-error retry replays a raised exception, the
+    empty-completion retry resamples a returned empty-shape result without
+    appending the empty assistant message and without advancing the outer turn
+    counter, and the output-length retry appends a ``role=user`` feedback turn
+    and resamples a truncated content-carrying result under its own budget
+    before falling through to accept-and-continue. Each owns a dedicated
+    ``LoopConfig`` field and each fires on a distinct trigger.
+    ``RATE_LIMIT``, ``API_TIMEOUT`` and ``TRIAL_LOST`` stay one-shot terminal
+    because each owns a dedicated path (typed 429 handling, transport-timeout
+    retry, substrate re-registration) and retrying them here would
+    double-count them.
 
     ``tool_output_max_chars`` caps the ``role=tool`` message ``content`` at
     that many chars via
@@ -145,6 +151,7 @@ class LoopConfig:
     api_error_retries: int = 1
     api_error_backoff_s: float = 1.0
     empty_retry_count: int = 0
+    output_length_retry_count: int = 0
     tool_output_max_chars: int | None = None
     max_context_tokens: int | None = None
     context_watermark: int | None = None
@@ -447,11 +454,16 @@ class ToolCallingLoop:
         successful turn followed by an API-error turn gets a fresh budget.
         Only :attr:`TerminationReason.API_ERROR` triggers a retry at this
         layer: rate limits, API timeouts and trial-lost stay one-shot
-        terminal. Empty completions are resampled inside :meth:`_run_turn`
-        under a separate budget (:attr:`LoopConfig.empty_retry_count`) so the
-        two retry classes stay orthogonal — the API-error retry replays a
-        raised exception, and the empty-completion retry resamples a returned
-        empty-shape result.
+        terminal. Empty completions and content-carrying max-tokens
+        truncations are resampled inside :meth:`_run_turn` under their own
+        budgets (:attr:`LoopConfig.empty_retry_count` and
+        :attr:`LoopConfig.output_length_retry_count`), so the three retry
+        classes stay orthogonal — the API-error retry replays a raised
+        exception, the empty-completion retry resamples a returned
+        empty-shape result, and the output-length retry appends a
+        ``role=user`` feedback turn and resamples a returned truncated
+        content-carrying result before falling through to
+        accept-and-continue.
         """
         api_error_attempts = 0
         while True:
@@ -499,6 +511,7 @@ class ToolCallingLoop:
             return summarize_decision.status, summarize_decision.reason, True
 
         empty_attempts = 0
+        output_length_attempts = 0
         while True:
             try:
                 result = self._generate(turn, system_prompt)
@@ -532,6 +545,31 @@ class ToolCallingLoop:
             self._log_generation(turn, result)
 
             if result.text or result.tool_calls:
+                if (
+                    result.finish_reason == "length"
+                    and output_length_attempts < self.config.output_length_retry_count
+                ):
+                    output_length_attempts += 1
+                    self._append_both(
+                        messages,
+                        Message(
+                            role=MessageRole.USER,
+                            content=(
+                                "The previous response was truncated at max_tokens "
+                                "(finish_reason: length). Please split the next "
+                                "action into smaller pieces (fewer tool calls per "
+                                "turn, shorter text) and try again."
+                            ),
+                            ts=_now(),
+                        ),
+                    )
+                    self.logger.info(
+                        "Resampling after truncated completion",
+                        turn=turn,
+                        attempt=output_length_attempts,
+                        max_attempts=self.config.output_length_retry_count + 1,
+                    )
+                    continue
                 break
 
             if empty_attempts >= self.config.empty_retry_count:

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -358,6 +358,7 @@ class TrialRunner:
                         max_turns=self.max_turns,
                         episode_timeout_s=self.episode_timeout_s,
                         empty_retry_count=capabilities.empty_retry_count,
+                        output_length_retry_count=capabilities.output_length_retry_count,
                         tool_output_max_chars=capabilities.tool_output_max_chars,
                         max_context_tokens=capabilities.max_context_tokens,
                         context_watermark=capabilities.context_watermark,


### PR DESCRIPTION
## Summary

- New opt-in engine seam: on a generation with `finish_reason == \"length\"` and non-empty content (visible truncation), the loop inserts a `role=user` feedback turn ("The previous response was truncated at max_tokens ... Please split the next action into smaller pieces ...") and resamples up to `output_length_retry_count` times. On budget exhaustion, the last truncated response is accepted as the assistant turn and the trial continues.
- Additive `ModelCapabilities.output_length_retry_count: int = 0` and `LoopConfig.output_length_retry_count: int = 0`. `GenerationResult` gains `finish_reason: str | None = None`, sourced from `choice.finish_reason` in the litellm response.
- No preset opts in this PR. Canonical routing test locks every currently-registered preset to `0`; opt-ins require per-model + per-workload observed truncation-rate evidence recorded in the preset comment (matching the discipline the sibling `empty_retry_count` opt-ins on `moonshot_kimi_k3` / `anthropic_claude_opus_5` use).

## Design choices

- **Ticket premise reframe.** The issue body said "engine-loop classifies output-length-exceeded as an API error → single retry → terminate". That's not what the code does today — `_assemble_result` never reads `choice.finish_reason` at all, litellm exposes no `MaxTokensExceededError`, and the current path silently accepts the partial response (with `_parse_tool_arguments` coercing truncated JSON args to `{}`). This PR adds a NEW seam that surfaces the truncation signal to the model rather than fixing a broken classifier.
- **`MessageRole.USER`, not `MessageRole.SYSTEM`, for the feedback turn.** Load-bearing per plan invariant 9: this is the FIRST `_run_turn` path that inserts a marker via `_append_both` AND continues the loop rather than terminating. Every existing inline `MessageRole.SYSTEM` marker (empty-completion, MAX_TURNS, summarize, TerminationDecision) is terminal, so litellm's Anthropic-adapter convention of hoisting inline `role=system` into the top-level `system` parameter is inert for them. On a non-terminal seam, that hoisting would prepend the truncation feedback to the initial system prompt instead of landing it mid-conversation — defeating the seam's design intent. A `role=user` feedback turn stays positional on every adapter (Anthropic / OpenAI / Gemini / Bedrock) and reads naturally as a user turn instructing the assistant.
- **Retry semantics: discard-and-resample with feedback, not accept-and-append.** Mirrors `empty_retry_count` exactly. Avoids leaving orphan `tool_calls` with partial args on the wire (Anthropic rejects an assistant turn with `tool_calls` that has no matching tool responses).
- **Exhaustion accepts the partial and continues, no new terminal reason.** The framing directive is "terminate is too aggressive"; the pre-opt-in baseline was silent accept-and-continue, so exhaustion preserves that byte-for-byte. A new `TerminationReason` value would require routing through failure-attribution and grading with no observed evidence to justify it.
- **`GenerationResult.finish_reason` is additive.** Every existing callsite constructs by kwargs; the new field defaults to `None`. Every existing test path is preserved. Downstream `_assemble_result` sources the value from `getattr(choice, "finish_reason", None)` so a wire response that omits it is safe.
- **`choice.finish_reason` detection surface only.** Litellm post-maps every current provider's max-tokens reason (`MAX_TOKENS`, `MAX_OUTPUT_TOKENS`, etc.) to the OpenAI-compatible `"length"`. Reading `provider_specific_fields.native_finish_reason` too would add three lines and a bit more test surface without covering any provider in the current registry.
- **Nested inside the content-carrying gate.** The retry branch nests inside `if result.text or result.tool_calls:` at `loop.py:534`, so `finish_reason=="length"` with zero content still routes through the empty-completion branch (`empty_retry_count`) rather than the length-retry branch. Locked by `test_length_finish_reason_with_empty_content_uses_empty_path` — a future refactor that flattens the nesting fails here.

## Concepts introduced

- **`ModelCapabilities.output_length_retry_count: int = 0`** — new numeric-knob slot, sibling to `empty_retry_count`, `default_max_turns`, `tool_output_max_chars`, `max_context_tokens`, `context_watermark`. `0` (default) preserves current byte-for-byte behaviour.
- **`LoopConfig.output_length_retry_count: int = 0`** — mirror on the loop config; threaded via `runner.py`, matching the empty-retry wiring.
- **`GenerationResult.finish_reason: str | None = None`** — new keyword-defaulted attribute. `None` when unset (test paths, older provider responses); populated from `choice.finish_reason` in `_assemble_result` otherwise.
- **Three retry classes, disjoint:** `API_ERROR` (raised exception, `_attempt_turn` outer loop), `EMPTY_COMPLETION` (empty-shape result, `_run_turn` empty branch), `OUTPUT_LENGTH` (content-carrying + `finish_reason=="length"`, new `_run_turn` nested branch). No cross-branch state leakage. `_attempt_turn` docstring rewritten from "two retry classes" to enumerate all three.

Nothing renamed, nothing removed. `EMPTY_COMPLETION` termination still fires on empty responses; length-retry only activates when opted in.

## Plan

See `~/.claude/plans/toloka-tolokaforge/issue-1498-output-length-salvage.md`. Two commits:

1. `3bfebbce feat(engine-loop): output-length retry-with-feedback seam` — Stage 1 (single-stage plan). `GenerationResult.finish_reason` ingestion + `ModelCapabilities` + `LoopConfig` slots + `_run_turn` nested retry-with-feedback branch (USER role) + 4 new unit tests + 1 new ingestion test + 1 new canonical routing test + `docs/LLM_LAYER.md § "Output-length retry"` subsection.

2. `b8094e48 chore(review): fix reviewer findings (hygiene 3 Blockers + correctness 1 Minor)` — review fixes. Three §7a rewrites drop "on this PR" / "lands in a follow-up" temporal language from the new canonical test docstring, assert message, and docs section. One new unit test (`test_length_finish_reason_with_empty_content_uses_empty_path`) locks the disjoint-path invariant per correctness reviewer Minor.

## Discovered issues

- **Filed / addressed**: pre-existing silent-accept of truncated responses (visible truncation was invisible to the model) — surfaced via the new seam when opted in.
- **Not filed (per user memory)**: two placeholders captured in the plan for later — observed-evidence preset opt-ins (candidate: `moonshot_kimi_k3`, `anthropic_claude_opus_5`) and surfacing `finish_reason` in trial artefacts / dashboards for slicing per-preset truncation rates. Both depend on this seam merging first so the observed-evidence run has something to measure.

## Test plan

- `pytest tests/unit/test_tool_calling_loop.py -v` — 5 new tests (4 seam + 1 disjoint-invariant) + existing regressions green.
- `pytest tests/unit/llm/test_generation_result_finish_reason.py -v` — new ingestion test (`stop` + `length` parametrized).
- `pytest tests/canonical/test_output_length_retry_count_preset_routing.py -v` — 10 registered presets all resolve to `0`.
- `pytest tests/unit/llm/ tests/unit/test_runner_logic.py tests/unit/test_runner_per_trial_cost_accounting.py tests/unit/test_failure_attribution.py -q` — regression sweep, 1168+ pass.
- `ruff check` + `black --check` + `ruff format --check`: clean.
- Pre-commit hooks: all passed.

Closes #1498.