### PR TITLE
feat(engine-loop): parser-error retry-with-feedback seam

### DIFF
--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -1865,6 +1865,66 @@ truncation rate recorded in the preset comment (matching the discipline
 `empty_retry_count`'s `moonshot_kimi_k3` / `anthropic_claude_opus_5`
 opt-ins use).
 
+### Parser-error retry
+
+A generation whose `tool_call.function.arguments` string cannot be decoded
+by `LLMClient._try_parse_tool_arguments`'s JSON / YAML / repair-JSON /
+repair-YAML ladder is structurally malformed: the model produced a
+tool_call, but its serialised arguments are not a dict any parser accepted.
+`_assemble_result` records one `ParserError(tool_name, raw_arguments,
+reason)` per failing call on the sidecar tuple `GenerationResult.parser_errors`
+alongside the tolerant `{}` coercion the parser applies. The raw arguments
+excerpt is bounded by `PARSER_ERROR_RAW_ARGS_EXCERPT_MAX_CHARS` (500 chars)
+so a long garbage payload does not inflate the feedback turn.
+
+When `capabilities.parser_error_retry_count > 0`, the loop discards the
+assistant response, appends a `role=user` feedback turn naming the failing
+tools, quoting the raw arguments excerpt, and reporting the parse reason,
+and resamples without appending the discarded assistant message and without
+advancing the outer turn counter. On budget exhaustion the loop falls
+through to accept-and-continue — the last (still-malformed) response lands
+as the assistant turn with its `{}`-coerced tool_calls preserved, and the
+executor either surfaces an `INVALID_ARGUMENTS` tool_result (for tools with
+a real schema that rejects `{}`) or runs the tool against empty args (for
+no-arg tools). The seam is strictly recoverable and never a new terminal
+reason. The metrics sink records every resampled generation because the
+trial paid for each call. The default `parser_error_retry_count = 0`
+accepts the `{}`-coerced response as the assistant turn unchanged — the
+seam is opt-in per preset.
+
+The feedback turn is `MessageRole.USER` — not `MessageRole.SYSTEM` — for
+the same load-bearing reason § *Output-length retry* documents above: this
+is the second `_run_turn` path that inserts a marker via `_append_both` AND
+continues the loop, so a `role=system` marker would be hoisted into the
+initial system prompt by litellm's Anthropic-adapter convention rather
+than landing mid-conversation, defeating the seam's intent. The `role=user`
+shape stays positional on every adapter and mirrors both the tool-response
+pattern and the output-length-retry pattern already provider-safe there.
+
+Orthogonal to `empty_retry_count` (empty-shape completion, terminates on
+exhaustion), `output_length_retry_count` (content-carrying max-tokens
+truncation), and the loop-level API-error retry (raised transient
+exception). Each retry class owns a distinct trigger — structurally
+malformed args, empty-shape completion, content-carrying truncation,
+raised transient exception — and a dedicated `LoopConfig` field so a
+preset can tune them independently. The parser-error branch nests
+*inside* the outer `if result.text or result.tool_calls:` gate and fires
+*before* the output-length branch, so a response that carries both
+signals (parser errors AND `finish_reason == "length"`) resamples under
+the parser-error budget first — the malformed args are the stronger
+signal because the response is structurally broken, not just cut off.
+
+`LoopConfig.parser_error_retry_count` flows from
+`capabilities.parser_error_retry_count` at
+[`runner.py`](../tolokaforge/core/runner.py) construction time. No
+preset opts in today; canonical
+[`tests/canonical/test_parser_error_retry_count_preset_routing.py`](../tests/canonical/test_parser_error_retry_count_preset_routing.py)
+enumerates every currently-registered preset and pins the default. An
+observed-evidence opt-in for a specific preset requires the per-workload
+parse-error rate recorded in the preset comment (matching the discipline
+`empty_retry_count`'s `moonshot_kimi_k3` / `anthropic_claude_opus_5`
+opt-ins use).
+
 ### Context-window handoff
 
 `ModelCapabilities.max_context_tokens: int | None` and
@@ -2505,18 +2565,24 @@ outer controllers above, transport-timeout retry in
 protocol. Retrying them at the loop level would double-count the exclusion and
 confuse the denominator.
 
-The empty-completion retry and the output-length retry are two separate
-classes that live in `_run_turn`, each under its own budget on
-`LoopConfig.empty_retry_count` and `LoopConfig.output_length_retry_count`.
-The three retry classes are orthogonal — each fires on a distinct
-trigger: the API-error retry replays a *raised exception*, the
-empty-completion retry resamples a *returned empty-shape result* (see §
-*Provider-side empty completion* above for the resample mechanics and
-the Gemini-legal-tail invariant), and the output-length retry appends a
-`role=user` feedback turn and resamples a *returned content-carrying
-truncation* under its own budget before falling through to
-accept-and-continue (see § *Output-length retry* above). Each owns a
-dedicated `LoopConfig` field so a preset can tune them independently.
+The empty-completion retry, the output-length retry and the parser-error
+retry are three separate classes that live in `_run_turn`, each under its
+own budget on `LoopConfig.empty_retry_count`,
+`LoopConfig.output_length_retry_count` and
+`LoopConfig.parser_error_retry_count`. The four retry classes are
+orthogonal — each fires on a distinct trigger: the API-error retry
+replays a *raised exception*, the empty-completion retry resamples a
+*returned empty-shape result* (see § *Provider-side empty completion*
+above for the resample mechanics and the Gemini-legal-tail invariant),
+the output-length retry appends a `role=user` feedback turn and
+resamples a *returned content-carrying truncation* under its own budget
+before falling through to accept-and-continue (see § *Output-length
+retry* above), and the parser-error retry appends a `role=user` feedback
+turn naming the failing tools and resamples a *returned response with
+un-parseable tool_call arguments* under its own budget before falling
+through to accept the `{}`-coerced response (see § *Parser-error retry*
+above). Each owns a dedicated `LoopConfig` field so a preset can tune
+them independently.
 
 `TerminationReason.CONTEXT_WINDOW_EXCEEDED` is a third wire-shape reason
 (parallel to `EMPTY_COMPLETION`), not routed through the API-error retry.

--- a/tests/canonical/test_parser_error_retry_count_preset_routing.py
+++ b/tests/canonical/test_parser_error_retry_count_preset_routing.py
@@ -1,0 +1,47 @@
+"""Canonical test — preset → ``parser_error_retry_count`` routing.
+
+Every currently-registered preset resolves to the default
+``parser_error_retry_count == 0``. Opting a preset in requires per-model
++ per-workload observed evidence for the un-parseable-arguments shape,
+recorded in the preset comment; the opt-in doubles reasoning spend on the
+failing sample, so a blanket enable is inappropriate.
+
+An unintentional preset opt-in fails this test. The right move on a
+failure is to remove the offending overlay entry, not to mute the
+assertion — matching the discipline
+``test_output_length_retry_count_preset_routing.py`` establishes for the
+sibling retry class.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.llm import build_capabilities
+
+pytestmark = pytest.mark.canonical
+
+
+_PARSER_ERROR_RETRY_ZERO_MODELS = [
+    ("openai/gpt-4o", "openrouter"),
+    ("anthropic/claude-opus-4.7", "openrouter"),
+    ("anthropic/claude-sonnet-4.7", "openrouter"),
+    ("openai/gpt-5.5", "openrouter"),
+    ("x-ai/grok-4", "openrouter"),
+    ("qwen/qwen3-coder", "openrouter"),
+    ("google/gemini-3.1-pro-preview", "openrouter"),
+    ("moonshotai/kimi-k3", "openrouter"),
+    ("moonshotai/kimi-k2.6", "openrouter"),
+    ("claude-opus-5", "anthropic"),
+]
+
+
+@pytest.mark.parametrize(("model", "provider"), _PARSER_ERROR_RETRY_ZERO_MODELS)
+def test_preset_leaves_parser_error_retry_count_zero(model: str, provider: str) -> None:
+    caps = build_capabilities(model, provider)
+    assert caps.parser_error_retry_count == 0, (
+        f"{model!r} must resolve to parser_error_retry_count=0. Opt-ins "
+        "require per-workload parse-error-rate evidence recorded in the "
+        "preset comment; if you intended to opt this preset in, add the "
+        f"evidence there rather than mute this assertion. Got: {caps.parser_error_retry_count}."
+    )

--- a/tests/unit/test_model_client.py
+++ b/tests/unit/test_model_client.py
@@ -282,6 +282,30 @@ class TestParseToolArguments:
         assert isinstance(result["actions"], list)
         assert result["actions"][0]["type"] == "click"
 
+    def test_try_parse_tool_arguments_returns_reason_on_exhaustion(self) -> None:
+        """``_try_parse_tool_arguments`` ingests the same raw shapes as its
+        wrapper but reports whether every parser exhausted. Locks the seam
+        the loop's parser-error retry reads on ``GenerationResult.parser_errors``:
+        exhausted → ``({}, "Unable to parse...")``, recovered / native-dict /
+        provider-sent-no-args → ``({...}, None)``."""
+        client = _make_client()
+
+        parsed, reason = client._try_parse_tool_arguments("search", '{"a": ]')
+        assert parsed == {}
+        assert reason == "Unable to parse with JSON/YAML fallbacks"
+
+        parsed, reason = client._try_parse_tool_arguments("search", '{"q": 1}')
+        assert parsed == {"q": 1}
+        assert reason is None
+
+        parsed, reason = client._try_parse_tool_arguments("search", None)
+        assert parsed == {}
+        assert reason is None
+
+        parsed, reason = client._try_parse_tool_arguments("search", "[1, 2, 3]")
+        assert parsed == {}
+        assert reason is None
+
 
 # ===================================================================
 # _tool_block_format and supports_tool_image_blocks

--- a/tests/unit/test_tool_calling_loop.py
+++ b/tests/unit/test_tool_calling_loop.py
@@ -19,7 +19,7 @@ import time
 import pytest
 from litellm.exceptions import RateLimitError
 
-from tolokaforge.core.llm.client import GenerationResult, LLMApiTimeoutError
+from tolokaforge.core.llm.client import GenerationResult, LLMApiTimeoutError, ParserError
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.logging import get_logger
 from tolokaforge.core.loop import (
@@ -855,6 +855,325 @@ def test_length_finish_reason_with_empty_content_uses_empty_path():
         m.role == MessageRole.USER and "truncated at max_tokens" in (m.content or "")
         for m in messages
     )
+
+
+def _result_with_parser_errors(
+    *,
+    text: str = "call",
+    tool_calls: list[ToolCall],
+    parser_errors: tuple[ParserError, ...],
+    prompt_tokens: int = 3,
+) -> GenerationResult:
+    """Build a scripted ``GenerationResult`` with a ``parser_errors`` sidecar
+    populated the way ``LLMClient._assemble_result`` populates it."""
+    result = GenerationResult(
+        text=text,
+        tool_calls=tool_calls,
+        usage=Usage(prompt_tokens=prompt_tokens),
+    )
+    result.parser_errors = parser_errors
+    return result
+
+
+def test_parser_error_not_retried_when_opt_out():
+    """With ``parser_error_retry_count=0`` (the default) a response carrying
+    ``parser_errors`` lands as the assistant turn unchanged and the loop
+    advances normally — the ``{}``-coerced tool_call is handed to the
+    executor. No user-feedback marker is inserted. Locks the default-off
+    invariant against silent drift."""
+    executor = _RecordingExecutor()
+    client = _ScriptedClient(
+        [
+            _result_with_parser_errors(
+                text="broken",
+                tool_calls=[ToolCall(id="a", name="query", arguments={})],
+                parser_errors=(
+                    ParserError(
+                        tool_name="query",
+                        raw_arguments='{"broken',
+                        reason="Unable to parse with JSON/YAML fallbacks",
+                    ),
+                ),
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        executor=executor,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            parser_error_retry_count=0,
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 1
+    assistant_messages = [m for m in messages if m.role == MessageRole.ASSISTANT]
+    assert len(assistant_messages) == 1
+    assert executor.executed == [("query", {}, "a")]
+    assert not any(
+        m.role == MessageRole.USER and "tool_call argument parse errors" in (m.content or "")
+        for m in messages
+    )
+    assert outcome.termination_reason == TerminationReason.MAX_TURNS
+
+
+def test_parser_error_resamples_and_recovers():
+    """With ``parser_error_retry_count=1``, the first response has non-empty
+    ``parser_errors`` and is discarded; a ``role=user`` parse-error feedback
+    turn is appended to both the recorded history and the wire history; the
+    second (parser-clean) sample is executed. Locks the recovery shape and
+    pins that the feedback actually reaches the wire on the retry call."""
+    executor = _RecordingExecutor()
+    sink = _CountingSink()
+    client = _ScriptedClient(
+        [
+            _result_with_parser_errors(
+                text="broken",
+                tool_calls=[ToolCall(id="a", name="query", arguments={})],
+                parser_errors=(
+                    ParserError(
+                        tool_name="query",
+                        raw_arguments='{"broken',
+                        reason="Unable to parse with JSON/YAML fallbacks",
+                    ),
+                ),
+            ),
+            GenerationResult(
+                text="ok",
+                tool_calls=[ToolCall(id="b", name="query", arguments={"q": 1})],
+                usage=Usage(prompt_tokens=5),
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        executor=executor,
+        sink=sink,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            parser_error_retry_count=1,
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 2
+    assert sink.generations == 2  # (c) both generations bill the metrics sink.
+
+    # (a) exactly one user-feedback turn carrying the parser-error phrasing,
+    # the failing tool name, the raw args snippet, and the reason.
+    feedback_turns = [
+        m
+        for m in messages
+        if m.role == MessageRole.USER and "tool_call argument parse errors" in (m.content or "")
+    ]
+    assert len(feedback_turns) == 1
+    feedback_content = feedback_turns[0].content or ""
+    assert "'query'" in feedback_content
+    assert '{"broken' in feedback_content
+    assert "Unable to parse with JSON/YAML fallbacks" in feedback_content
+
+    # (b) the discarded assistant message (with the failed tool_call) is NOT
+    # in the recorded history.
+    assert not any(m.role == MessageRole.ASSISTANT and m.content == "broken" for m in messages)
+    assistant_messages = [m for m in messages if m.role == MessageRole.ASSISTANT]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].content == "ok"
+
+    # (d) wire-level lock: the SECOND generate call's messages list ends with
+    # the parser-error feedback user turn — the retry with feedback actually
+    # reaches the provider, not just the recorded trajectory.
+    second_call_messages = client.messages_history[1]
+    tail = second_call_messages[-1]
+    assert tail.role == MessageRole.USER
+    assert "tool_call argument parse errors" in (tail.content or "")
+
+    # (e) the recovered tool_call was executed with the recovered args.
+    assert executor.executed == [("query", {"q": 1}, "b")]
+
+    assert outcome.termination_reason == TerminationReason.MAX_TURNS
+
+
+def test_parser_error_exhausts_and_accepts_last_response():
+    """With ``parser_error_retry_count=1``, two consecutive responses both
+    carry ``parser_errors``: the budget exhausts on the second one, the
+    second response DOES land as the assistant turn (its ``{}``-coerced
+    tool_calls preserved), and the executor runs it against the empty args.
+    The loop continues normally — no new terminal — the exhaustion path is
+    strictly recoverable."""
+    executor = _RecordingExecutor()
+    client = _ScriptedClient(
+        [
+            _result_with_parser_errors(
+                text="broken-1",
+                tool_calls=[ToolCall(id="a", name="query", arguments={})],
+                parser_errors=(
+                    ParserError(
+                        tool_name="query",
+                        raw_arguments='{"broken-1',
+                        reason="Unable to parse with JSON/YAML fallbacks",
+                    ),
+                ),
+            ),
+            _result_with_parser_errors(
+                text="broken-2",
+                tool_calls=[ToolCall(id="b", name="query", arguments={})],
+                parser_errors=(
+                    ParserError(
+                        tool_name="query",
+                        raw_arguments='{"broken-2',
+                        reason="Unable to parse with JSON/YAML fallbacks",
+                    ),
+                ),
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        executor=executor,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            parser_error_retry_count=1,
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 2
+    assert outcome.termination_reason == TerminationReason.MAX_TURNS
+    assert outcome.status == TrialStatus.COMPLETED
+
+    assistant_messages = [m for m in messages if m.role == MessageRole.ASSISTANT]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].content == "broken-2"
+
+    feedback_turns = [
+        m
+        for m in messages
+        if m.role == MessageRole.USER and "tool_call argument parse errors" in (m.content or "")
+    ]
+    assert len(feedback_turns) == 1
+
+    assert executor.executed == [("query", {}, "b")]
+
+
+def test_parser_error_retry_does_not_advance_turn_counter():
+    """Resamples happen within the same outer turn. With ``max_turns=1`` and
+    ``parser_error_retry_count=2`` the loop absorbs two parse-error resamples
+    on turn 0 and executes the recovered tool call also on turn 0 (three
+    generations, one outer turn — mirrors the sibling retry-class tests)."""
+    executor = _RecordingExecutor()
+    client = _ScriptedClient(
+        [
+            _result_with_parser_errors(
+                text="broken-1",
+                tool_calls=[ToolCall(id="a", name="query", arguments={})],
+                parser_errors=(
+                    ParserError(
+                        tool_name="query",
+                        raw_arguments='{"broken-1',
+                        reason="Unable to parse with JSON/YAML fallbacks",
+                    ),
+                ),
+            ),
+            _result_with_parser_errors(
+                text="broken-2",
+                tool_calls=[ToolCall(id="b", name="query", arguments={})],
+                parser_errors=(
+                    ParserError(
+                        tool_name="query",
+                        raw_arguments='{"broken-2',
+                        reason="Unable to parse with JSON/YAML fallbacks",
+                    ),
+                ),
+            ),
+            GenerationResult(
+                text="ok",
+                tool_calls=[ToolCall(id="c", name="query", arguments={"q": 1})],
+                usage=Usage(prompt_tokens=5),
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        executor=executor,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            parser_error_retry_count=2,
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 3
+    assert executor.executed == [("query", {"q": 1}, "c")]
+    assert outcome.termination_reason == TerminationReason.MAX_TURNS
+
+
+def test_parser_error_feedback_content_lists_all_failing_tools():
+    """A single response with TWO parser errors: assert the feedback turn
+    names BOTH tools and BOTH reasons — a multi-tool failure must not
+    silently drop one, or the model would re-emit whichever it did not see.
+    Locks the multi-error formatting contract of
+    ``_format_parser_error_feedback``."""
+    executor = _RecordingExecutor()
+    client = _ScriptedClient(
+        [
+            _result_with_parser_errors(
+                text="two broken",
+                tool_calls=[
+                    ToolCall(id="a", name="query", arguments={}),
+                    ToolCall(id="b", name="search", arguments={}),
+                ],
+                parser_errors=(
+                    ParserError(
+                        tool_name="query",
+                        raw_arguments='{"q":',
+                        reason="Unable to parse with JSON/YAML fallbacks",
+                    ),
+                    ParserError(
+                        tool_name="search",
+                        raw_arguments='{"term":',
+                        reason="Unable to parse with JSON/YAML fallbacks",
+                    ),
+                ),
+            ),
+            GenerationResult(
+                text="ok",
+                tool_calls=[ToolCall(id="c", name="query", arguments={"q": 1})],
+                usage=Usage(prompt_tokens=5),
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    _loop(
+        client,
+        should_terminate=_never_terminate,
+        executor=executor,
+        config=LoopConfig(
+            max_turns=1,
+            episode_timeout_s=10_000,
+            parser_error_retry_count=1,
+        ),
+    ).run("sys", messages, time.time())
+
+    feedback_turns = [
+        m
+        for m in messages
+        if m.role == MessageRole.USER and "tool_call argument parse errors" in (m.content or "")
+    ]
+    assert len(feedback_turns) == 1
+    content = feedback_turns[0].content or ""
+    assert "'query'" in content
+    assert "'search'" in content
+    assert '{"q":' in content
+    assert '{"term":' in content
 
 
 def test_api_error_retry_budget_resets_per_outer_turn():

--- a/tolokaforge/core/llm/capabilities.py
+++ b/tolokaforge/core/llm/capabilities.py
@@ -148,6 +148,31 @@ class ModelCapabilities:
     because the trial paid for each call.
     """
 
+    parser_error_retry_count: int = 0
+    """Resample budget for a response whose ``tool_call.function.arguments``
+    string could not be decoded by :meth:`LLMClient._try_parse_tool_arguments`.
+
+    On a returned ``GenerationResult`` with non-empty ``parser_errors``, the
+    engine appends a ``role=user`` feedback turn naming the failing tools,
+    quoting the raw arguments excerpt, and reporting the parse reason, then
+    resamples up to ``parser_error_retry_count`` times without appending the
+    discarded assistant message and without advancing the outer turn counter.
+    On budget exhaustion the loop falls through to accept-and-continue: the
+    ``{}``-coerced assistant response lands and either the tool executor
+    surfaces an ``INVALID_ARGUMENTS`` tool_result (for tools with a real
+    schema) or the tool runs against empty args (for no-arg tools) —
+    reproducing today's behaviour byte-for-byte. The seam is strictly
+    recoverable and never a new terminal reason.
+
+    Orthogonal to :attr:`empty_retry_count` (empty-shape completion,
+    terminates on exhaustion), :attr:`output_length_retry_count`
+    (content-carrying max-tokens truncation), and the loop-level API-error
+    retry (raised exception). Each retry class owns a distinct trigger and a
+    dedicated budget. The default ``0`` accepts the ``{}``-coerced response
+    as the assistant turn unchanged — the seam is opt-in per preset. Metrics
+    record every resampled generation because the trial paid for each call.
+    """
+
     tool_output_max_chars: int | None = None
     """Loop-layer cap on the ``role=tool`` message content, in chars.
 

--- a/tolokaforge/core/llm/capabilities.py
+++ b/tolokaforge/core/llm/capabilities.py
@@ -160,9 +160,8 @@ class ModelCapabilities:
     On budget exhaustion the loop falls through to accept-and-continue: the
     ``{}``-coerced assistant response lands and either the tool executor
     surfaces an ``INVALID_ARGUMENTS`` tool_result (for tools with a real
-    schema) or the tool runs against empty args (for no-arg tools) —
-    reproducing today's behaviour byte-for-byte. The seam is strictly
-    recoverable and never a new terminal reason.
+    schema) or the tool runs against empty args (for no-arg tools). The
+    seam is strictly recoverable and never a new terminal reason.
 
     Orthogonal to :attr:`empty_retry_count` (empty-shape completion,
     terminates on exhaustion), :attr:`output_length_retry_count`

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -102,10 +102,9 @@ PARSER_ERROR_RAW_ARGS_EXCERPT_MAX_CHARS = 500
 @dataclass(frozen=True)
 class ParserError:
     """Sidecar record of one un-parseable ``tool_call.function.arguments``
-    string. Ephemeral in-process value object per the AGENTS.md type table —
-    never crosses a wire boundary and never serialised into ``Trajectory`` or
-    task artefacts, so a frozen dataclass fits and ``ReplyDefect`` (Pydantic)
-    is the wrong shape.
+    string. Ephemeral in-process value; never crosses a wire boundary and
+    never serialised into ``Trajectory`` or task artefacts, so a frozen
+    dataclass fits and ``ReplyDefect`` (Pydantic) is the wrong shape.
 
     ``raw_arguments`` is the original ``tc.function.arguments`` string
     (verbatim, so the retry feedback can quote it back), bounded by

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -17,6 +17,7 @@ import re
 import threading
 import time
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -85,8 +86,38 @@ __all__ = [
     "GenerationResult",
     "LLMApiTimeoutError",
     "LLMClient",
+    "ParserError",
     "UserSimulator",
 ]
+
+# Bound on the raw-arguments excerpt carried by ``ParserError.raw_arguments``.
+# A malformed tool_call args payload has enough surrounding context at 500
+# chars for the model to locate its syntactic issue on the resample. Distinct
+# from ``REPLY_DEFECT_EXCERPT_MAX_CHARS`` (200): that constant caps a
+# substring-match excerpt around a suspicious span, this one caps the whole
+# malformed payload — different use cases, tuned independently.
+PARSER_ERROR_RAW_ARGS_EXCERPT_MAX_CHARS = 500
+
+
+@dataclass(frozen=True)
+class ParserError:
+    """Sidecar record of one un-parseable ``tool_call.function.arguments``
+    string. Ephemeral in-process value object per the AGENTS.md type table —
+    never crosses a wire boundary and never serialised into ``Trajectory`` or
+    task artefacts, so a frozen dataclass fits and ``ReplyDefect`` (Pydantic)
+    is the wrong shape.
+
+    ``raw_arguments`` is the original ``tc.function.arguments`` string
+    (verbatim, so the retry feedback can quote it back), bounded by
+    :data:`PARSER_ERROR_RAW_ARGS_EXCERPT_MAX_CHARS`. ``reason`` is the parse
+    failure phrase — the exception message from the last failing parser or
+    ``"Unable to parse with JSON/YAML fallbacks"`` when every fallback
+    exhausted.
+    """
+
+    tool_name: str
+    raw_arguments: str
+    reason: str
 
 
 _module_logger = get_logger("llm_client_cost")
@@ -561,6 +592,14 @@ class GenerationResult:
         # Stamped only by ``UserSimulator._llm_reply``; every other producer
         # of a result leaves it empty.
         self.guard_rejections: tuple[ReplyDefect, ...] = ()
+        # One ``ParserError`` per ``tool_call.function.arguments`` string that
+        # ``_try_parse_tool_arguments`` could not decode. Stamped by
+        # ``LLMClient._assemble_result`` alongside the ``{}`` coercion the
+        # tolerant parser applies. Read by ``ToolCallingLoop._run_turn``'s
+        # parser-error retry seam to decide whether to discard the response,
+        # append ``role=user`` parse-error feedback naming the failing tools,
+        # and resample under ``LoopConfig.parser_error_retry_count``.
+        self.parser_errors: tuple[ParserError, ...] = ()
         # True iff ``UserSimulator._llm_reply`` substituted the fixed filler
         # for a tool-call-only reply with no text. Callers whose downstream
         # semantics depend on the model having written the text (the
@@ -1081,8 +1120,25 @@ class LLMClient:
 
         return repaired
 
-    def _parse_tool_arguments(self, tool_name: str, raw_args: Any) -> dict[str, Any]:
-        """Parse model-emitted tool arguments with tolerant fallbacks."""
+    def _try_parse_tool_arguments(
+        self, tool_name: str, raw_args: Any
+    ) -> tuple[dict[str, Any], str | None]:
+        """Parse model-emitted tool arguments with tolerant fallbacks and
+        report whether every parser exhausted.
+
+        Returns ``(parsed, error_reason)``. ``error_reason`` is ``None`` on
+        any recovery branch that yielded a dict (including the "provider
+        legitimately sent no args" branch: ``None`` / empty string / non-str)
+        and on the shape-mismatch branch (JSON parsed but yielded a list or
+        scalar rather than a dict — a shape issue rather than a parse
+        failure). It is a short human phrase (``"Unable to parse with
+        JSON/YAML fallbacks"``) only when every parser in the JSON / YAML /
+        repair-JSON / repair-YAML ladder failed to yield any dict.
+
+        Read by :meth:`_assemble_result` to populate
+        :attr:`GenerationResult.parser_errors` alongside the tolerant ``{}``
+        coercion the engine's parser-error retry seam consumes.
+        """
 
         def _normalize(parsed_args: dict[str, Any]) -> dict[str, Any]:
             normalized = dict(parsed_args)
@@ -1105,17 +1161,17 @@ class LLMClient:
             return normalized
 
         if isinstance(raw_args, dict):
-            return _normalize(raw_args)
+            return _normalize(raw_args), None
         if raw_args is None or not isinstance(raw_args, str):
-            return {}
+            return {}, None
 
         args_str = raw_args.strip()
         if not args_str:
-            return {}
+            return {}, None
 
         try:
             parsed = json.loads(args_str)
-            return _normalize(parsed) if isinstance(parsed, dict) else {}
+            return (_normalize(parsed) if isinstance(parsed, dict) else {}), None
         except json.JSONDecodeError:
             pass
 
@@ -1123,7 +1179,7 @@ class LLMClient:
             parsed = yaml.safe_load(args_str)
             if isinstance(parsed, dict):
                 self.logger.warning("Recovered malformed tool arguments", tool=tool_name)
-                return _normalize(parsed)
+                return _normalize(parsed), None
         except Exception:
             pass
 
@@ -1134,7 +1190,7 @@ class LLMClient:
                 parsed = parser(repaired)
                 if isinstance(parsed, dict):
                     self.logger.warning("Recovered malformed tool arguments", tool=tool_name)
-                    return _normalize(parsed)
+                    return _normalize(parsed), None
             except Exception:
                 continue
 
@@ -1143,7 +1199,19 @@ class LLMClient:
             tool=tool_name,
             error="Unable to parse with JSON/YAML fallbacks",
         )
-        return {}
+        return {}, "Unable to parse with JSON/YAML fallbacks"
+
+    def _parse_tool_arguments(self, tool_name: str, raw_args: Any) -> dict[str, Any]:
+        """Tolerant parse of model-emitted tool arguments.
+
+        Thin wrapper over :meth:`_try_parse_tool_arguments` that discards the
+        parse-error phrase. Existing callers that only need the ``{}``-coerced
+        dict use this signature; :meth:`_assemble_result` calls the ``_try``
+        variant directly to stamp
+        :attr:`GenerationResult.parser_errors`.
+        """
+        parsed, _ = self._try_parse_tool_arguments(tool_name, raw_args)
+        return parsed
 
     # ------------------------------------------------------------------
     # Tool content adaptation
@@ -2218,9 +2286,21 @@ class LLMClient:
         # tool-call argument set the model emits.
         param_types_by_tool = _root_param_types_by_tool(sanitized_tools)
 
+        parser_errors_list: list[ParserError] = []
         if hasattr(message, "tool_calls") and message.tool_calls:
             for tc in message.tool_calls:
-                arguments = self._parse_tool_arguments(tc.function.name, tc.function.arguments)
+                raw = tc.function.arguments
+                arguments, parse_reason = self._try_parse_tool_arguments(tc.function.name, raw)
+                if parse_reason is not None:
+                    raw_str = raw if isinstance(raw, str) else str(raw)
+                    excerpt = raw_str[:PARSER_ERROR_RAW_ARGS_EXCERPT_MAX_CHARS]
+                    parser_errors_list.append(
+                        ParserError(
+                            tool_name=tc.function.name,
+                            raw_arguments=excerpt,
+                            reason=parse_reason,
+                        )
+                    )
                 arguments = self.capabilities.response_policy.parse_arguments(
                     arguments,
                     param_types=param_types_by_tool.get(tc.function.name),
@@ -2271,7 +2351,7 @@ class LLMClient:
             gateway_route_kind=self._gateway_route_kind,
         )
 
-        return GenerationResult(
+        result = GenerationResult(
             text=text,
             tool_calls=tool_calls,
             usage=usage,
@@ -2288,6 +2368,12 @@ class LLMClient:
             # that carries no finish_reason at all lands as ``None``.
             finish_reason=getattr(choice, "finish_reason", None),
         )
+        # Attribute-post-init idiom matches ``guard_rejections`` and
+        # ``filler_substituted``. Any other producer of a ``GenerationResult``
+        # (mock generator, inline test constructions) inherits the ``()``
+        # default and the seam is inert.
+        result.parser_errors = tuple(parser_errors_list)
+        return result
 
     # ------------------------------------------------------------------
     # Mock generator (offline tests)

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -1052,6 +1052,7 @@ def build_capabilities(
     api_call_wall_timeout_s = cfg.get("api_call_wall_timeout_s")
     empty_retry_count = cfg.get("empty_retry_count")
     output_length_retry_count = cfg.get("output_length_retry_count")
+    parser_error_retry_count = cfg.get("parser_error_retry_count")
     tool_output_max_chars = cfg.get("tool_output_max_chars")
     default_max_turns = cfg.get("default_max_turns")
     max_context_tokens = cfg.get("max_context_tokens")
@@ -1076,6 +1077,9 @@ def build_capabilities(
         empty_retry_count=int(empty_retry_count) if empty_retry_count is not None else 0,
         output_length_retry_count=(
             int(output_length_retry_count) if output_length_retry_count is not None else 0
+        ),
+        parser_error_retry_count=(
+            int(parser_error_retry_count) if parser_error_retry_count is not None else 0
         ),
         tool_output_max_chars=(
             int(tool_output_max_chars) if tool_output_max_chars is not None else None

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -8,16 +8,24 @@ the same machinery.
 The engine is deliberately behaviour-light: it owns turn structure (episode
 timeout, generate, accumulate, append assistant, terminate, execute tools,
 optional user turn, error classification, max-turns), and delegates every
-*policy* decision to pluggable seams. A provider-shaped *empty completion* —
-``result.text == "" and not result.tool_calls`` — is the one wire-shape
-observation the engine consumes directly: it resamples up to
+*policy* decision to pluggable seams. The engine consumes three wire-shape
+observations directly: the provider-shaped *empty completion* —
+``result.text == "" and not result.tool_calls`` — resamples up to
 ``LoopConfig.empty_retry_count`` times without appending the empty assistant
 message, and on the ``(N + 1)``-th empty result terminates the trial with
-:attr:`TerminationReason.EMPTY_COMPLETION`. The Gemini-legal-tail invariant is
+:attr:`TerminationReason.EMPTY_COMPLETION` (the Gemini-legal-tail invariant is
 preserved end-to-end because the empty message is never appended — appending
-it would send a request whose tail is an empty ``role=model`` turn on the next
-iteration and providers such as Gemini reject that as an API error rather than
-pass it through.
+it would send a request whose tail is an empty ``role=model`` turn on the
+next iteration and providers such as Gemini reject that as an API error
+rather than pass it through); the content-carrying *max-tokens truncation* —
+``result.finish_reason == "length"`` on a content-carrying result —
+resamples with a ``role=user`` feedback turn under
+``LoopConfig.output_length_retry_count`` before falling through to
+accept-and-continue; and the *un-parseable tool_call arguments* —
+``result.parser_errors`` non-empty — resamples with a ``role=user``
+feedback turn naming the failing tools and quoting the raw arguments under
+``LoopConfig.parser_error_retry_count`` before falling through to accept the
+``{}``-coerced response.
 
 The loop also owns a defensive bound on tool-output size that lands in the
 message history: when ``LoopConfig.tool_output_max_chars`` is set,
@@ -64,6 +72,7 @@ import litellm.exceptions
 from tolokaforge.core.llm.client import (
     GenerationResult,
     LLMApiTimeoutError,
+    ParserError,
     is_typed_rate_limit_exception,
     matches_rate_limit_text,
 )
@@ -117,18 +126,22 @@ class LoopConfig:
     provider fault the classifier could not attribute to a typed reason.
     ``empty_retry_count`` sets the resample budget for a returned empty
     completion; ``output_length_retry_count`` sets the resample budget for a
-    content-carrying max-tokens truncation. The three retry classes are
-    orthogonal — the API-error retry replays a raised exception, the
-    empty-completion retry resamples a returned empty-shape result without
-    appending the empty assistant message and without advancing the outer turn
-    counter, and the output-length retry appends a ``role=user`` feedback turn
-    and resamples a truncated content-carrying result under its own budget
-    before falling through to accept-and-continue. Each owns a dedicated
-    ``LoopConfig`` field and each fires on a distinct trigger.
-    ``RATE_LIMIT``, ``API_TIMEOUT`` and ``TRIAL_LOST`` stay one-shot terminal
-    because each owns a dedicated path (typed 429 handling, transport-timeout
-    retry, substrate re-registration) and retrying them here would
-    double-count them.
+    content-carrying max-tokens truncation; ``parser_error_retry_count`` sets
+    the resample budget for a response whose ``tool_call.function.arguments``
+    string could not be decoded. The four retry classes are orthogonal — the
+    API-error retry replays a raised exception, the empty-completion retry
+    resamples a returned empty-shape result without appending the empty
+    assistant message and without advancing the outer turn counter, the
+    output-length retry appends a ``role=user`` feedback turn and resamples a
+    truncated content-carrying result under its own budget before falling
+    through to accept-and-continue, and the parser-error retry appends a
+    ``role=user`` feedback turn naming the failing tools and resamples under
+    its own budget before falling through to accept the ``{}``-coerced
+    response. Each owns a dedicated ``LoopConfig`` field and each fires on a
+    distinct trigger. ``RATE_LIMIT``, ``API_TIMEOUT`` and ``TRIAL_LOST`` stay
+    one-shot terminal because each owns a dedicated path (typed 429 handling,
+    transport-timeout retry, substrate re-registration) and retrying them
+    here would double-count them.
 
     ``tool_output_max_chars`` caps the ``role=tool`` message ``content`` at
     that many chars via
@@ -152,6 +165,7 @@ class LoopConfig:
     api_error_backoff_s: float = 1.0
     empty_retry_count: int = 0
     output_length_retry_count: int = 0
+    parser_error_retry_count: int = 0
     tool_output_max_chars: int | None = None
     max_context_tokens: int | None = None
     context_watermark: int | None = None
@@ -454,16 +468,20 @@ class ToolCallingLoop:
         successful turn followed by an API-error turn gets a fresh budget.
         Only :attr:`TerminationReason.API_ERROR` triggers a retry at this
         layer: rate limits, API timeouts and trial-lost stay one-shot
-        terminal. Empty completions and content-carrying max-tokens
-        truncations are resampled inside :meth:`_run_turn` under their own
-        budgets (:attr:`LoopConfig.empty_retry_count` and
-        :attr:`LoopConfig.output_length_retry_count`), so the three retry
+        terminal. Empty completions, content-carrying max-tokens truncations
+        and un-parseable tool_call arguments are resampled inside
+        :meth:`_run_turn` under their own budgets
+        (:attr:`LoopConfig.empty_retry_count`,
+        :attr:`LoopConfig.output_length_retry_count` and
+        :attr:`LoopConfig.parser_error_retry_count`), so the four retry
         classes stay orthogonal — the API-error retry replays a raised
         exception, the empty-completion retry resamples a returned
-        empty-shape result, and the output-length retry appends a
-        ``role=user`` feedback turn and resamples a returned truncated
-        content-carrying result before falling through to
-        accept-and-continue.
+        empty-shape result, the output-length retry appends a ``role=user``
+        feedback turn and resamples a returned truncated content-carrying
+        result before falling through to accept-and-continue, and the
+        parser-error retry appends a ``role=user`` feedback turn naming the
+        failing tools and resamples before falling through to accept the
+        ``{}``-coerced response.
         """
         api_error_attempts = 0
         while True:
@@ -512,6 +530,7 @@ class ToolCallingLoop:
 
         empty_attempts = 0
         output_length_attempts = 0
+        parser_error_attempts = 0
         while True:
             try:
                 result = self._generate(turn, system_prompt)
@@ -545,6 +564,27 @@ class ToolCallingLoop:
             self._log_generation(turn, result)
 
             if result.text or result.tool_calls:
+                if (
+                    result.parser_errors
+                    and parser_error_attempts < self.config.parser_error_retry_count
+                ):
+                    parser_error_attempts += 1
+                    self._append_both(
+                        messages,
+                        Message(
+                            role=MessageRole.USER,
+                            content=self._format_parser_error_feedback(result.parser_errors),
+                            ts=_now(),
+                        ),
+                    )
+                    self.logger.info(
+                        "Resampling after tool_call argument parse errors",
+                        turn=turn,
+                        attempt=parser_error_attempts,
+                        max_attempts=self.config.parser_error_retry_count + 1,
+                        tool_names=[e.tool_name for e in result.parser_errors],
+                    )
+                    continue
                 if (
                     result.finish_reason == "length"
                     and output_length_attempts < self.config.output_length_retry_count
@@ -901,3 +941,24 @@ class ToolCallingLoop:
     @staticmethod
     def _system_message(content: str) -> Message:
         return Message(role=MessageRole.SYSTEM, content=content, ts=_now())
+
+    @staticmethod
+    def _format_parser_error_feedback(errors: tuple[ParserError, ...]) -> str:
+        """Render the ``role=user`` feedback body for the parser-error retry.
+
+        Lists every failing tool_call so a multi-error response does not
+        silently drop one of the parse failures — the model would otherwise
+        re-emit whichever one it did not see. Kept as a static method so a
+        unit test can call it directly with a synthesised
+        :class:`ParserError` tuple.
+        """
+        lines = [
+            "The previous response had tool_call argument parse errors and could not be executed:"
+        ]
+        for e in errors:
+            lines.append(f"- tool={e.tool_name!r}: {e.reason}. Raw arguments: {e.raw_arguments!r}")
+        lines.append(
+            "Please fix these issues and provide valid JSON arguments "
+            "for each tool call, then try again."
+        )
+        return "\n".join(lines)

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -359,6 +359,7 @@ class TrialRunner:
                         episode_timeout_s=self.episode_timeout_s,
                         empty_retry_count=capabilities.empty_retry_count,
                         output_length_retry_count=capabilities.output_length_retry_count,
+                        parser_error_retry_count=capabilities.parser_error_retry_count,
                         tool_output_max_chars=capabilities.tool_output_max_chars,
                         max_context_tokens=capabilities.max_context_tokens,
                         context_watermark=capabilities.context_watermark,


### PR DESCRIPTION
## Summary

Adds an opt-in `parser_error_retry_count` seam on `ModelCapabilities` (default `0`). When `LLMClient._assemble_result` observes a `tool_call.function.arguments` string that exhausts the JSON / YAML / repair-JSON / repair-YAML ladder, it records one `ParserError(tool_name, raw_arguments, reason)` per failing call on the new `GenerationResult.parser_errors` sidecar alongside today's tolerant `{}` coercion. `ToolCallingLoop._run_turn` reads the sidecar inside the existing content-carrying gate: with a remaining budget it discards the assistant response, appends a `role=user` feedback turn naming the failing tools (with the raw arguments excerpt bounded by `PARSER_ERROR_RAW_ARGS_EXCERPT_MAX_CHARS = 500`) and resamples without appending the discarded turn or advancing the outer turn counter. On budget exhaustion the loop falls through to the pre-existing accept-and-continue path.

The seam is strictly recoverable — never a new `TerminationReason` — and completes the four-class retry taxonomy (API-error, empty-completion, output-length, parser-error). Each retry class owns a distinct trigger, a dedicated budget, and its own canonical preset-routing test.

Closes #1499.

## Design choices

| Decision | Rationale |
|---|---|
| Additive `parser_error_retry_count: int = 0` slot on `ModelCapabilities` + `LoopConfig` | Numeric-knob shape mirrors `empty_retry_count` and `output_length_retry_count`; opt-in per preset preserves current behaviour byte-for-byte on every registered preset. |
| `ParserError` as a frozen dataclass on `client.py` (not Pydantic) | Ephemeral in-process value object; never crosses a wire boundary or lands in `Trajectory`. `ReplyDefect` is Pydantic because it serialises into the trial artefact; `ParserError` does not. |
| Sidecar sourced at `_assemble_result` via a new `_try_parse_tool_arguments` companion | Keeps `_parse_tool_arguments`'s tolerant `{}`-coercion contract intact — its nine existing tests still pass unmodified. The companion returns `(parsed, reason)`; the wrapper discards the reason. |
| Feedback turn is `MessageRole.USER`, not `MessageRole.SYSTEM` | This is the second `_run_turn` path that inserts a marker via `_append_both` and continues the loop; litellm's Anthropic-adapter convention hoists inline `role=system` messages into the top-level `system` parameter, which would defeat the seam's mid-conversation intent. Matches the load-bearing rationale documented for output-length retry. |
| Parser-error retry fires BEFORE output-length retry inside the content-carrying gate | A parse error is a stronger signal than a truncation (the response is structurally broken, not just cut off); firing first keeps the two budgets independent. |
| `PARSER_ERROR_RAW_ARGS_EXCERPT_MAX_CHARS = 500` (not `200` like `REPLY_DEFECT_EXCERPT_MAX_CHARS`) | A parser-error excerpt is the whole malformed args payload — the model needs enough surrounding context to locate the syntactic issue on resample. `ReplyDefect`'s 200 covers a substring-match span around a suspicious marker (a `<think>` tag, an all-caps refusal), a distinct use case tuned independently. |
| No preset opts in this PR | Opt-ins require per-model + per-workload observed evidence recorded in the preset comment; a canonical parametrised test locks every currently-registered preset to `parser_error_retry_count == 0` so a silent opt-in fails the build. |

## Test plan
- [x] `tests/unit/test_tool_calling_loop.py` — five new tests: default-off, resample-and-recover (with wire-level `messages_history[1]` tail lock), exhaustion accepts `{}`-coerced response, retry does not advance outer turn counter, multi-tool feedback lists every failing tool.
- [x] `tests/unit/test_model_client.py` — one new test locking `_try_parse_tool_arguments`'s `(parsed, reason)` return contract across exhaustion, success, `None`, and non-dict-JSON (list) inputs.
- [x] `tests/canonical/test_parser_error_retry_count_preset_routing.py` — new canonical parametrised over the 10 currently-registered presets, all pinned to `parser_error_retry_count == 0`.
- [x] `tests/unit/test_runner_per_trial_cost_accounting.py` — regression check green (MagicMock-stub-new-attr gotcha did not fire here because the new attribute is not read on the accounting path).
- [x] `tests/unit/test_failure_attribution.py` — regression check green (attribution rule set unchanged).
- [x] Sibling canonicals `test_empty_retry_count_preset_routing.py` + `test_output_length_retry_count_preset_routing.py` remain green.
- [x] Ruff + Black + import-boundary all green.