### PR TITLE
fix(tbench-adapter): route agent system prompt through the inline policies escape

### DIFF
--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
@@ -320,7 +320,7 @@ class TerminalBenchAdapter(CodingHarnessAdapterMixin, BaseAdapter):
                 user={"enabled": []},
             ),
             grading="__adapter__",
-            system_prompt="__adapter__",
+            policies={"agent_system_prompt": self.get_system_prompt(task_id)},
             environment_manifest=self._environment_patch(task_id),
             adapter_settings={
                 "difficulty": meta.difficulty,

--- a/tests/canonical/snapshots/tbench_echo_hello/task_config.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_config.json
@@ -61,9 +61,11 @@
     "tags": []
   },
   "name": "echo-hello",
-  "policies": {},
+  "policies": {
+    "agent_system_prompt": "You are an expert developer working inside a Linux container. Use the bash tool to execute commands. Fix the issues described in the user message."
+  },
   "stuck_heuristics": null,
-  "system_prompt": "__adapter__",
+  "system_prompt": null,
   "task_id": "echo-hello",
   "timeouts": null,
   "tools": {

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -494,6 +494,48 @@ class TestTerminalBenchAdapterEnvironmentManifest:
         assert extra == {"service": env.agent_service, "compose_project_prefix": "tbench_"}
 
 
+class TestTerminalBenchAgentSystemPromptVerbatim:
+    """T-Bench authors its own agent system prompt via ``policies``, so the
+    engine returns it verbatim without applying the ``<instructions>`` /
+    ``<policy>`` wrap the ``__adapter__`` sentinel triggers.
+
+    The engine's sentinel branch is a customer-service persona wrap
+    (``tolokaforge/core/system_prompt.py:_wrap_policy_document``) — a shape
+    T-Bench's dev-tool tasks do not want.
+    ``TaskConfig.policies["agent_system_prompt"]`` is priority 1 in the
+    engine's chain, returned verbatim; T-Bench opts into that path
+    instead.
+    """
+
+    @pytest.fixture
+    def fixture_dir(self) -> Path:
+        return Path(__file__).parent.parent / "data" / "terminal_bench_tasks"
+
+    @pytest.fixture
+    def adapter(self, fixture_dir, tmp_path):
+        from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
+
+        return TerminalBenchAdapter(
+            {"terminal_bench_dir": str(fixture_dir), "staging_root": str(tmp_path)}
+        )
+
+    def test_task_config_carries_prompt_in_policies_not_sentinel(self, adapter):
+        task = adapter.get_task("echo-hello")
+        assert task.system_prompt is None
+        assert task.policies["agent_system_prompt"] == adapter.get_system_prompt("echo-hello")
+
+    def test_engine_returns_adapter_prompt_verbatim(self, adapter, tmp_path):
+        from tolokaforge.core.system_prompt import build_system_prompt
+
+        task = adapter.get_task("echo-hello")
+        assembled = build_system_prompt(task=task, task_dir=tmp_path, adapter=adapter)
+
+        assert assembled == adapter.get_system_prompt("echo-hello")
+        assert "<instructions>" not in assembled
+        assert "<policy>" not in assembled
+        assert "customer service" not in assembled.lower()
+
+
 class TestTerminalBenchAdapterInstructionlessTask:
     """A pack whose instruction carries no text pins no opener, so the simulator
     writes turn 1.


### PR DESCRIPTION
## Summary

The engine's ``build_system_prompt`` wraps ``__adapter__``-sentinel adapter output in a customer-service persona envelope (``tolokaforge/core/system_prompt.py:_AGENT_INSTRUCTION_WITH_TOOLS``), which contradicts T-Bench's dev-tool instruction body — the assembled prompt ends up asking the model to be *both* a customer-service agent *and* an expert developer, resolving inconsistently on every trial.

T-Bench now authors its own agent system prompt on ``TaskConfig.policies["agent_system_prompt"]`` (priority 1 in the engine's system-prompt chain, returned verbatim) and drops ``system_prompt="__adapter__"``. The framing decision moves out of the engine's shared wrap template and into the adapter that owns it. **The change is adapter-local — zero engine touch.** Every other adapter that today uses ``__adapter__`` keeps the existing wrap.

Closes #1500.

## Design choices

| Decision | Rationale |
|---|---|
| Adapter uses the engine's existing priority-1 ``policies["agent_system_prompt"]`` escape | The engine already exposes an "inline string, no wrap" escape hatch at the top of ``build_system_prompt``'s priority chain. T-Bench opts into it. No new adapter method, no new engine seam, no ``Literal`` enum. |
| No engine change | The customer-service wrap is a shared engine default that other packs today may rely on. Removing it entirely is a larger cleanup that would need a task-pack audit; that stays out of this ticket. Any adapter that wants a different framing takes the same escape hatch T-Bench now uses. |
| ``get_system_prompt(task_id)`` retained on the adapter | Kept as the authoritative source for T-Bench's prompt string. ``get_task`` calls it and threads the result into ``policies``. |

## Test plan
- [x] ``tests/unit/test_terminal_bench.py::TestTerminalBenchAgentSystemPromptVerbatim`` — two new tests: (a) ``TaskConfig`` carries the prompt in ``policies`` with ``system_prompt=None``, (b) ``build_system_prompt`` returns the adapter's string verbatim with no envelope tags or customer-service phrasing.
- [x] ``tests/unit/test_system_prompt.py`` — engine's own priority-chain tests remain green; the ``__adapter__`` branch is unchanged for adapters that still use the sentinel.
- [x] ``tests/canonical/test_agent_prompt_exit_token.py`` — green; the assertion at line 63 that guards packs against sending an ``__adapter__``-routed prompt through the ``adapter=None`` walk becomes a no-op for T-Bench (it now takes the inline branch).
- [x] Canonical snapshot ``tests/canonical/snapshots/tbench_echo_hello/task_config.json`` regenerated to match the new shape.
- [x] Ruff + Black + import-boundary all green.