### PR TITLE
fix(grader-v3): carry tolokaforge.grading_methods + grader_kinds into the runner-subset wheel

### DIFF
--- a/scripts/hatch/hatch_runner_subset_builder.py
+++ b/scripts/hatch/hatch_runner_subset_builder.py
@@ -80,6 +80,8 @@ RUNNER_REACHABLE_ENTRY_POINT_GROUPS: tuple[str, ...] = (
     "tolokaforge.transcript_rule_matchers",
     "tolokaforge.state_check_backends",
     "tolokaforge.trace_check_operators",
+    "tolokaforge.grading_methods",
+    "tolokaforge.grader_kinds",
 )
 
 

--- a/tests/canonical/test_runner_subset_partition.py
+++ b/tests/canonical/test_runner_subset_partition.py
@@ -653,6 +653,8 @@ _LOADER_TO_GROUP: dict[str, str] = {
     "load_state_check_backend": "tolokaforge.state_check_backends",
     "load_trace_check_operator": "tolokaforge.trace_check_operators",
     "load_grading_substrate": "tolokaforge.grading_substrates",
+    "load_grading_method": "tolokaforge.grading_methods",
+    "load_grader_kind": "tolokaforge.grader_kinds",
 }
 
 


### PR DESCRIPTION
## Summary

The runner-subset wheel ships without the two Grader v3 entry-point groups (``tolokaforge.grading_methods`` and ``tolokaforge.grader_kinds``), so the runner container's ``RegisterTrial`` gate at ``tolokaforge/runner/service.py:893-906`` refuses every trial that names a Grader v3 grading method with ``Unknown grading_method ...; registered names ... : []``. Every non-native adapter (T-Bench and any adapter using ``composite`` or ``test_execution`` methods) is broken on the standard docker stack since v0.23.0.

Root cause: ``RUNNER_REACHABLE_ENTRY_POINT_GROUPS`` in ``scripts/hatch/hatch_runner_subset_builder.py:76-84`` is the allowlist of entry-point groups the subset wheel carries. Grader v3 added the two new groups to root ``pyproject.toml`` but did not add them to the allowlist. The subset builder builds a wheel whose ``entry_points.txt`` has empty sections for both groups.

The two drift-lock tests in ``tests/canonical/test_runner_subset_partition.py`` did not catch this:

- ``test_subset_wheel_carries_runner_reachable_entry_point_groups`` compares built wheel to allowlist. Both are missing the groups, so they agree.
- ``test_subset_partition_load_calls_are_in_the_allowlist`` maps ``load_*`` seams to groups via ``_LOADER_TO_GROUP``. Grader v3's ``load_grading_method`` and ``load_grader_kind`` were not added to the map, so this test couldn't detect the omission either.

Closes #1526.

## Design choices

| Decision | Rationale |
|---|---|
| Add both groups to ``RUNNER_REACHABLE_ENTRY_POINT_GROUPS`` | Symmetric with the sibling grading-plumbing groups (``custom_check_executors``, ``judge_model_providers``, etc.). Both loaders (``load_grading_method`` / ``load_grader_kind``) are reached from the runner-side ``RegisterTrial`` handler. |
| Add both entries to ``_LOADER_TO_GROUP`` | Closes the drift direction that let this land silently — the drift-lock now catches a future runner-side ``load_*`` seam whose group is missing from the allowlist, matching the discipline in place for every sibling loader. |
| No runtime code change | Root cause is packaging, not runtime. Two entries in two ``dict``/``tuple`` literals; no behaviour change beyond "the subset wheel now carries what its runtime already expected to find." |

## Test plan
- [x] ``tests/canonical/test_runner_subset_partition.py`` — 17 passed, including the extended ``_LOADER_TO_GROUP`` drift-lock.
- [x] Runner rebuild (``make docker-build-core``) + T-Bench smoke reaches grade time. Applied the same one-tuple-entry-list edit temporarily to a rebased branch tree, rebuilt the runner image, ran ``examples/terminal_bench`` (both ``fix-airline-segmentation`` and ``fix-billing-holds``, 1 repeat, sonnet-4-6 via OpenRouter):
  - ``fix-airline-segmentation``: pass=True, score=0.867, 34 turns, $0.34
  - ``fix-billing-holds``: pass=True, score=0.600, 33 turns, $0.46
  - Aggregate: 2/2, ``success_rate_micro=1.0``, ``failed_attempts=0``, ``stuck_rate=0.0``, total $0.80.