### PR TITLE
refactor(grading): rename RunnerGradeComponents → CompositeGradeComponents; move to core.grading (#1399)

### DIFF
--- a/tests/canonical/test_composite_grade_components_shape.py
+++ b/tests/canonical/test_composite_grade_components_shape.py
@@ -60,11 +60,13 @@ def test_unknown_key_fails_loud() -> None:
         CompositeGradeComponents.model_validate({"definitely_unknown_key": 1})
 
 
-def test_runner_models_does_not_re_export_the_old_name() -> None:
-    """Guards against a well-meaning "let me re-add it as a compat re-export".
+def test_runner_models_does_not_export_runner_grade_components() -> None:
+    """``tolokaforge.runner.models`` does not expose ``RunnerGradeComponents``.
 
-    The rename removed ``RunnerGradeComponents`` from ``runner.models``
-    with no shim and no ``__getattr__`` alias. A re-export sneaking back in
-    would revive the cross-boundary import the rename eliminated.
+    A re-export (module attribute, ``from ... import ... as`` alias, or
+    ``__getattr__`` shim) would create a cross-boundary import from the
+    composite grading dispatchers into ``runner.models`` — the exact
+    coupling ``CompositeGradeComponents`` lives in ``core.grading`` to
+    prevent.
     """
     assert not hasattr(runner_models, "RunnerGradeComponents")

--- a/tests/canonical/test_composite_grade_components_shape.py
+++ b/tests/canonical/test_composite_grade_components_shape.py
@@ -1,0 +1,70 @@
+"""Shape lock for :class:`CompositeGradeComponents`.
+
+The wire-side score container both composite dispatchers populate is
+substrate-neutral by construction: the runner-side ``_grade_trial_async``,
+the grader-side :class:`GraderCompositeDispatch`, and the offline
+:class:`CompositeGraderKind` all fold sub-component scores through this
+one Pydantic class before the composite fold combines them. A drift in
+its identity, field set, or strictness would silently change what every
+dispatcher is allowed to write into a Grade — hence the lock.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.core.grading.grade_components import CompositeGradeComponents
+from tolokaforge.runner import models as runner_models
+
+pytestmark = pytest.mark.canonical
+
+
+_EXPECTED_FIELDS = frozenset(
+    {
+        "hash_match",
+        "hash_score",
+        "jsonpath_score",
+        "jsonpath_reasons",
+        "db_probe_score",
+        "db_probe_reasons",
+        "transcript_pass",
+        "transcript_score",
+        "trace_checks_score",
+        "llm_judge_score",
+        "llm_judge_reasons",
+        "custom_checks_score",
+    }
+)
+
+
+def test_lives_in_core_grading_grade_components() -> None:
+    """The class's canonical home is co-located with ``GRADE_COMPONENTS``.
+
+    A re-import from a moved-away shim would change ``__module__`` and
+    silently reintroduce a cross-boundary import into ``runner.models``.
+    """
+    assert CompositeGradeComponents.__module__ == "tolokaforge.core.grading.grade_components"
+
+
+def test_field_set_is_the_twelve_composite_slots() -> None:
+    assert set(CompositeGradeComponents.model_fields) == _EXPECTED_FIELDS
+
+
+def test_extra_forbid_is_the_strict_contract() -> None:
+    assert CompositeGradeComponents.model_config["extra"] == "forbid"
+
+
+def test_unknown_key_fails_loud() -> None:
+    with pytest.raises(ValidationError):
+        CompositeGradeComponents.model_validate({"definitely_unknown_key": 1})
+
+
+def test_runner_models_does_not_re_export_the_old_name() -> None:
+    """Guards against a well-meaning "let me re-add it as a compat re-export".
+
+    The rename removed ``RunnerGradeComponents`` from ``runner.models``
+    with no shim and no ``__getattr__`` alias. A re-export sneaking back in
+    would revive the cross-boundary import the rename eliminated.
+    """
+    assert not hasattr(runner_models, "RunnerGradeComponents")

--- a/tests/canonical/test_grade_component_registry_canon.py
+++ b/tests/canonical/test_grade_component_registry_canon.py
@@ -2,10 +2,10 @@
 
 Five independently maintained sources have to agree on what a component is: the
 registry, the core ``GradeComponents`` model, the proto ``GradeComponents``
-descriptor, the score-carrying fields on the runner's own model, and the
+descriptor, the score-carrying fields on ``CompositeGradeComponents``, and the
 ``grading.yaml`` sections ``GradingConfig`` declares. Three are compared by
-name; the other two are resolution checks, because the runner names its scores
-``*_score`` and one component has no single runner field at all.
+name; the other two are resolution checks, because scores are named ``*_score``
+and one component has no single dedicated field at all.
 
 A sixth component added to any one source without the others is what these tests
 exist to catch — that is the shape the plan for #678 found seven times over,
@@ -19,11 +19,15 @@ from typing import Any
 import pytest
 
 from tests.utils.wire_grades import lower_wire_grade
-from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS, component_requested
+from tolokaforge.core.grading.grade_components import (
+    GRADE_COMPONENTS,
+    CompositeGradeComponents,
+    component_requested,
+)
 from tolokaforge.core.models import GradeComponents as CoreGradeComponents
 from tolokaforge.core.models import GradingConfig, StateChecksConfig
 from tolokaforge.runner import runner_pb2
-from tolokaforge.runner.models import RunnerGradeComponents, RunnerGradingConfig
+from tolokaforge.runner.models import RunnerGradingConfig
 
 pytestmark = [pytest.mark.canonical, pytest.mark.grading]
 
@@ -53,7 +57,7 @@ def test_every_registered_component_arrives_under_its_own_key() -> None:
 
 
 def test_every_runner_score_field_resolves_on_the_runner_model() -> None:
-    declared = set(RunnerGradeComponents.model_fields)
+    declared = set(CompositeGradeComponents.model_fields)
     unresolved = [
         spec.runner_score_field
         for spec in GRADE_COMPONENTS

--- a/tests/canonical/test_grading_composite_state_checks.py
+++ b/tests/canonical/test_grading_composite_state_checks.py
@@ -201,7 +201,7 @@ class TestJsonpathCompositeParity:
 
 class TestEmptyPacksLeaveTheComponentsUntouched:
     """A pack that carried no jsonpath and no probe leaves both slots
-    ``None`` so the runner does not overwrite ``RunnerGradeComponents``
+    ``None`` so the runner does not overwrite ``CompositeGradeComponents``
     with sentinels the combine treats as evaluated."""
 
     def test_no_jsonpaths_no_probes_returns_all_none(self) -> None:

--- a/tests/canonical/test_grading_substrate_dispatch.py
+++ b/tests/canonical/test_grading_substrate_dispatch.py
@@ -53,7 +53,7 @@ from tolokaforge.core.grading.composite_fold import (
     compose_trial_verdict,
     resolve_state_checks_component,
 )
-from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS
+from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS, CompositeGradeComponents
 from tolokaforge.core.grading.judge_result import JudgeStatus
 from tolokaforge.core.grading.key_manifest import EVALUATED
 from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
@@ -89,7 +89,6 @@ from tolokaforge.runner.models import (
     LLMJudgeConfig,
     PresentConstraint,
     Rubric,
-    RunnerGradeComponents,
     RunnerGradingConfig,
     RunnerInitialStateConfig,
     RunnerStateChecksConfig,
@@ -395,7 +394,7 @@ def _reassemble_grade_from_composite(
         llm_messages = list(_LLM_MESSAGES)
         timeline = build_timeline_from_wire(llm_messages, trial_context.recorded, None)
 
-        components = RunnerGradeComponents()
+        components = CompositeGradeComponents()
         accounted_keys: dict[str, Any] = {}
 
         state_reads = composite.grade_state_checks_reads(

--- a/tests/canonical/test_runner_models_reconcile.py
+++ b/tests/canonical/test_runner_models_reconcile.py
@@ -58,7 +58,6 @@ from tolokaforge.runner.models import (
     RecordedToolCall,
     RequiredAction,
     Rubric,
-    RunnerGradeComponents,
     RunnerGradingConfig,
     RunnerInitializationAction,
     RunnerInitialStateConfig,
@@ -210,7 +209,6 @@ def test_reconciled_wire_types_forbid_extras():
         RunnerInitializationAction,
         {"env_type": "assistant", "tool_name": "t"},
     )
-    _requires_forbid(RunnerGradeComponents, {})
 
 
 @pytest.mark.parametrize("retired", ["first_message", "user_context"])

--- a/tolokaforge/core/grading/composite/state_checks.py
+++ b/tolokaforge/core/grading/composite/state_checks.py
@@ -33,10 +33,10 @@ class StateChecksReadResult:
     ``jsonpath_score`` / ``db_probe_score`` are ``None`` when the composite
     did not reach an assertion for that half — an empty checks list, or a
     probe-less pack — and the runner leaves the corresponding
-    :class:`RunnerGradeComponents` slot untouched (which then folds as
-    'component not evaluated'). Every author key the composite reached is
-    added to ``accounted_keys`` so the caller can merge it into the
-    RPC-level ledger.
+    :class:`~tolokaforge.core.grading.grade_components.CompositeGradeComponents`
+    slot untouched (which then folds as 'component not evaluated'). Every
+    author key the composite reached is added to ``accounted_keys`` so the
+    caller can merge it into the RPC-level ledger.
     """
 
     jsonpath_score: float | None

--- a/tolokaforge/core/grading/grade_components.py
+++ b/tolokaforge/core/grading/grade_components.py
@@ -25,6 +25,39 @@ from pydantic import BaseModel
 from tolokaforge.core.grading.checks_helpers import custom_checks_enabled
 
 
+class CompositeGradeComponents(BaseModel):
+    """Score-carrying wire model both composite dispatchers populate.
+
+    The runner-side ``_grade_trial_async``, the grader-side
+    :class:`~tolokaforge.grader.composite_dispatch.GraderCompositeDispatch`,
+    and the offline :class:`~tolokaforge.core.grading.kinds.composite.CompositeGraderKind`
+    all fold their sub-component scores into an instance of this class before
+    :class:`~tolokaforge.core.grading.composite_fold.CompositeFold` combines
+    them. Substrate-neutral by construction — the class carries no
+    dispatch-specific fields.
+
+    Sentinel-form contract: score fields default to ``-1.0`` (not evaluated),
+    boolean pass/match fields default to ``None`` (not evaluated), and
+    reason strings default to ``""``. The fold reads the sentinel form when
+    deciding whether a component was scored.
+    """
+
+    hash_match: bool | None = None
+    hash_score: float = -1.0
+    jsonpath_score: float = -1.0
+    jsonpath_reasons: str = ""
+    db_probe_score: float = -1.0
+    db_probe_reasons: str = ""
+    transcript_pass: bool | None = None
+    transcript_score: float = -1.0
+    trace_checks_score: float = -1.0
+    llm_judge_score: float = -1.0
+    llm_judge_reasons: str = ""
+    custom_checks_score: float = -1.0
+
+    model_config = {"extra": "forbid"}
+
+
 @dataclass(frozen=True)
 class GradeComponentSpec:
     """One grading component's identity across the config, the wire and both substrates.

--- a/tolokaforge/core/grading/kinds/composite.py
+++ b/tolokaforge/core/grading/kinds/composite.py
@@ -184,6 +184,7 @@ class CompositeGraderKind:
         import json as _json
 
         from tolokaforge.core.grading import composite
+        from tolokaforge.core.grading.grade_components import CompositeGradeComponents
         from tolokaforge.core.grading.substrate import SubstrateUnreachableError
         from tolokaforge.core.grading.tool_artifacts import extract_tool_artifacts
         from tolokaforge.core.grading.trace_timeline import build_timeline_from_wire
@@ -199,7 +200,6 @@ class CompositeGraderKind:
             load_transcript_rule_matcher,
         )
         from tolokaforge.runner.models import (
-            RunnerGradeComponents,
             TaskDescription,
             TraceChecksSummary,
             TraceConstraintResult,
@@ -306,7 +306,7 @@ class CompositeGraderKind:
                     judge_model_provider=judge_model_provider,
                     logger=logger,
                     composite_mod=composite,
-                    runner_components_cls=RunnerGradeComponents,
+                    composite_components_cls=CompositeGradeComponents,
                     load_rubric_evaluator=load_rubric_evaluator,
                     judge_status_cls=JudgeStatus,
                     trace_summary_cls=TraceChecksSummary,
@@ -345,7 +345,7 @@ class CompositeGraderKind:
         judge_model_provider: Any,
         logger: Any,
         composite_mod: Any,
-        runner_components_cls: Any,
+        composite_components_cls: Any,
         load_rubric_evaluator: Any,
         judge_status_cls: Any,
         trace_summary_cls: Any,
@@ -361,7 +361,7 @@ class CompositeGraderKind:
         from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
         from tolokaforge.runner.models import TraceChecksResult
 
-        components = runner_components_cls()
+        components = composite_components_cls()
         state_checks_config = task_config.state_checks
 
         if state_checks_config and (

--- a/tolokaforge/grader/composite_dispatch.py
+++ b/tolokaforge/grader/composite_dispatch.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, Any
 from tolokaforge.core.grading import composite
 from tolokaforge.core.grading.checks_interface import CheckResult
 from tolokaforge.core.grading.composite_fold import CompositeFold, CompositeFoldResult
+from tolokaforge.core.grading.grade_components import CompositeGradeComponents
 from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
 from tolokaforge.core.grading.substrate import SubstrateUnreachableError
 from tolokaforge.core.grading.tool_artifacts import extract_tool_artifacts
@@ -72,7 +73,6 @@ from tolokaforge.core.plugin_registry import (
 )
 from tolokaforge.core.trial_grader import GradingFailedError
 from tolokaforge.runner.models import (
-    RunnerGradeComponents,
     RunnerGradingConfig,
     TaskDescription,
 )
@@ -250,7 +250,7 @@ class GraderCompositeDispatch:
         timeline = build_timeline_from_wire(
             llm_messages, [], parse_termination_reason(dispatch.termination_reason)
         )
-        components = RunnerGradeComponents()
+        components = CompositeGradeComponents()
         state_checks_config = grading_config.state_checks
         self._grade_state_checks_block(
             trial_id=trial_id,
@@ -322,7 +322,7 @@ class GraderCompositeDispatch:
         trial_id: str,
         state_checks_config: Any,
         substrate: GradingSubstrate,
-        components: RunnerGradeComponents,
+        components: CompositeGradeComponents,
     ) -> None:
         """Run the ``state_checks`` reads block and fold results onto ``components``."""
         if not state_checks_config:
@@ -349,7 +349,7 @@ class GraderCompositeDispatch:
         trial_id: str,
         config: Any,
         timeline: Any,
-        components: RunnerGradeComponents,
+        components: CompositeGradeComponents,
     ) -> TranscriptEvaluationResult | None:
         """Run the transcript-rules block and fold the pass / score onto ``components``."""
         if not config:
@@ -372,7 +372,7 @@ class GraderCompositeDispatch:
         trial_id: str,
         config: Any,
         timeline: Any,
-        components: RunnerGradeComponents,
+        components: CompositeGradeComponents,
     ) -> TraceChecksResult:
         """Run the trace-checks block; populate ``components.trace_checks_score`` when scored."""
         if not config:
@@ -396,7 +396,7 @@ class GraderCompositeDispatch:
         llm_messages: list[dict[str, Any]],
         substrate: GradingSubstrate,
         artifacts_dir: Any,
-        components: RunnerGradeComponents,
+        components: CompositeGradeComponents,
     ) -> tuple[list[CheckResult], str | None]:
         """Run custom checks and fold the score onto ``components``.
 
@@ -428,7 +428,7 @@ class GraderCompositeDispatch:
         initial_state_schemas: list[Any],
         id_fields: dict[str, str | list[str]],
         unstable_fields: set[tuple[str, str]],
-        components: RunnerGradeComponents,
+        components: CompositeGradeComponents,
     ) -> tuple[JudgeResult | None, JudgeStatus, bool]:
         """Load the rubric-evaluator seam, render the state diff, and grade.
 
@@ -501,7 +501,7 @@ class GraderCompositeDispatch:
 def _build_grade(
     *,
     fold_result: CompositeFoldResult,
-    components: RunnerGradeComponents,
+    components: CompositeGradeComponents,
     custom_check_results: list[CheckResult],
     trace_result: TraceChecksResult,
     judge_result: JudgeResult | None,

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -15,7 +15,7 @@ The types in this module fall into three tiers:
 - **Runner-only wire types with a ``Runner`` prefix** —
   ``RunnerGradingConfig`` / ``RunnerStateChecksConfig`` /
   ``RunnerInitialStateConfig`` / ``RunnerInitializationAction`` /
-  ``RunnerUserSimulatorConfig`` / ``RunnerGradeComponents``. Each is the
+  ``RunnerUserSimulatorConfig``. Each is the
   strict, wire-shaped Pydantic model the runner produces or consumes;
   ``tolokaforge.core.models`` carries the sibling YAML-authoring shape under
   the unprefixed name for the same concern. The two live side by side
@@ -3658,25 +3658,6 @@ class TraceChecksResult(BaseModel):
     failed_gate_ids: list[str] = Field(default_factory=list)
     paths: list[TracePathResult] = Field(default_factory=list)
     accounted_keys: dict[str, KeyAccountingRecord] = Field(default_factory=dict)
-
-    model_config = {"extra": "forbid"}
-
-
-class RunnerGradeComponents(BaseModel):
-    """Component scores for grading."""
-
-    hash_match: bool | None = None
-    hash_score: float = -1.0  # -1.0 means not evaluated
-    jsonpath_score: float = -1.0  # -1.0 means not evaluated
-    jsonpath_reasons: str = ""
-    db_probe_score: float = -1.0  # -1.0 means not evaluated
-    db_probe_reasons: str = ""
-    transcript_pass: bool | None = None
-    transcript_score: float = -1.0
-    trace_checks_score: float = -1.0  # -1.0 means not evaluated
-    llm_judge_score: float = -1.0  # -1.0 means not evaluated
-    llm_judge_reasons: str = ""
-    custom_checks_score: float = -1.0  # -1.0 means not evaluated
 
     model_config = {"extra": "forbid"}
 

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -49,7 +49,7 @@ from tolokaforge.core.grading.golden_replay import (
     declared_failure,
     resolve_golden_action_names,
 )
-from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS
+from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS, CompositeGradeComponents
 from tolokaforge.core.grading.jsonpath_addressing import (
     addresses_the_database,
     block_addresses_the_database,
@@ -127,7 +127,6 @@ from tolokaforge.runner.models import (
     HashGradingResult,
     KeyAccountingRecord,
     RecordedToolCall,
-    RunnerGradeComponents,
     RunnerInitialStateConfig,
     RunnerStateChecksConfig,
     SearchConfig,
@@ -1871,7 +1870,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             )
 
         # Initialize grading components
-        components = RunnerGradeComponents()
+        components = CompositeGradeComponents()
         state_diff: StateDiff | None = None
         transcript_result: TranscriptEvaluationResult | None = None
         hash_result: HashGradingResult | None = None


### PR DESCRIPTION
## Summary

Rename the composite substrate's score-carrying Pydantic model from `RunnerGradeComponents` to `CompositeGradeComponents` and move it out of `tolokaforge/runner/models.py` (where it never belonged — the class crossed the substrate/composite boundary, not any runner wire) into `tolokaforge/core/grading/grade_components.py`, co-located with the `GRADE_COMPONENTS` registry that already names its fields.

Internal-only rename — no re-export shim, no `__getattr__` alias, no CHANGELOG entry. Zero external-adapter or workspace-package callers per grep of `external_adapters/`, `tools/`, `tolokaforge_coding_harnesses/`, `tolokaforge_models/`, `docs/`, `scripts/`.

Closes #1399.

## Design choices

| Decision | Rationale |
|---|---|
| New home is `core.grading.grade_components` (existing file) | Co-located with `GRADE_COMPONENTS` — the metadata registry that already names its fields. One file responsible for "what a grading component is", including the score-carrying model. |
| No compat shim in `runner.models` | Zero external callers. AGENTS.md § "fail-loud" beats an indefinite deprecation alias. Fail on `ImportError` at load time beats a silent `DeprecationWarning` nobody sees. |
| No CHANGELOG entry | Internal Python rename. No user-visible surface. No published API. Verified: `tolokaforge/__init__.py` and `tolokaforge/runner/__init__.py` never re-exported the class at the package level. |
| Fold `runner_components_cls=` → `composite_components_cls=` kwarg rename into the same commit | Three-line change in `kinds/composite.py`. Deferring to a separate PR would leave the kwarg semantically drifted from the class it accepts, and reviewer would flag it. |
| New canonical shape-lock file `tests/canonical/test_composite_grade_components_shape.py` | Grep-by-class-name finds the lock (AGENTS.md Gotcha #17). Migrates the `_requires_forbid` assertion out of `test_runner_models_reconcile.py::test_reconciled_wire_types_forbid_extras` — the reconcile test's persona is "runner-side wire types", which no longer names this class. |
| Include a `runner.models` re-export guard in the shape-lock | One-line canonical assertion (`assert not hasattr(runner_models, "RunnerGradeComponents")`) that defends against a future well-meaning re-export edit sneaking the class back into the runner-side surface. |

## Scope of change

- **20 references across 8 files rewired**: `runner/service.py` (2), `grader/composite_dispatch.py` (8), `core/grading/kinds/composite.py` (2), `core/grading/composite/state_checks.py` (1 docstring), `test_grading_substrate_dispatch.py` (2), `test_grade_component_registry_canon.py` (2), `test_runner_models_reconcile.py` (2), `test_grading_composite_state_checks.py` (1 docstring). Every callsite in the same commit.
- Module docstring at `runner/models.py:15-18` loses the `RunnerGradeComponents` mention from the "Runner-only wire types with a `Runner` prefix" enumeration.

## Test plan

- [x] `rg RunnerGradeComponents` returns exactly 2 hits, both inside the shape-lock's re-export guard (the class name + docstring). Every enumerated production callsite is at 0 hits.
- [x] `rg runner_components_cls` returns 0 hits.
- [x] New canonical shape-lock file exercises the 12-field set (frozenset), `extra="forbid"`, `ValidationError` on unknown key, and the runner-models re-export guard. 5 tests, all passing.
- [x] `uv run --active lint-imports` → 10 kept, 0 broken (baseline preserved; grader→runner import surface shrinks by one class).
- [x] `uv run --active pytest tests/canonical/test_composite_grade_components_shape.py tests/canonical/test_grade_component_registry_canon.py tests/canonical/test_runner_models_reconcile.py tests/canonical/test_grading_composite_state_checks.py tests/canonical/test_grading_substrate_dispatch.py` → 30 passed.
- [x] Full canonical lane → 2067 passed, 19 skipped, 1 pre-existing failure (`test_harness_registry_replay.py`, unrelated: baseline references rebased SHAs — same flake as v0.23.0 release cycle).
- [x] Narrow unit lane around the touched callers → 45 passed.

## Reviewer coverage

- **reviewer-correctness** → APPROVE (byte-clean field parity, defaults, `extra="forbid"`, kwarg rename symmetry, re-export guard actually asserts what it claims).
- **reviewer-type-fit** → APPROVE (Pydantic v2 + `extra="forbid"` preserved, `.importlinter` contracts satisfied and slightly tightened, registry resolution holds).
- **reviewer-hygiene** → APPROVE WITH NITS (one docstring-hygiene nit applied inline in follow-up commit `344a0967`: re-export guard function name + docstring rewritten in present-tense invariant form, no rename-as-history narration).

## Follow-ups

- **#1528** — rename `GradeComponentSpec.runner_score_field` → `composite_score_field` and the accessor beside it (metadata name-fit follow-up; kept out of #1399 to keep this PR mechanical).