### PR TITLE
feat(automation): page the Slack requester alone for model integrations

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -216,10 +216,18 @@ jobs:
           set -uo pipefail
           REQ="${INPUT_REQUESTED_BY:-}"
           if [ -z "$REQ" ]; then
-            # Newest-first, capped: the seed is the branch's oldest commit ahead of base and the
-            # only one carrying the trailer, so the first match is it; -n 50 bounds the log walk.
-            REQ="$(git log -n 50 --format=%B | sed -nE 's/^requested_by:[[:space:]]*//p' | head -1 | tr -d '[:space:]')"
+            # Scope to THIS branch's commits ahead of base (fetch-depth: 0 fetches origin/<base>):
+            # the seed carries the trailer and no integration commit does, so the first match is the
+            # seed's. Unscoped, `head -1` could pick a `requested_by:` line a prior squash-merge
+            # preserved in the base branch's own history and page an unrelated user. A missing
+            # origin/<base> (2>/dev/null) leaves REQ empty and the standing list takes over.
+            REQ="$(git log "origin/${GITHUB_BASE_REF:-main}..HEAD" --format=%B 2>/dev/null | sed -nE 's/^requested_by:[[:space:]]*//p' | head -1)"
           fi
+          # One line only: strip every whitespace / control char so a multi-line value (which the
+          # workflow_dispatch API accepts even where the web UI would not) cannot inject a second
+          # KEY=VALUE line into $GITHUB_ENV. Applied to BOTH sources. A valid Slack id carries none;
+          # `resolve_mentions` re-validates the shape before it is rendered into a mention.
+          REQ="$(printf '%s' "$REQ" | tr -d '[:space:][:cntrl:]')"
           printf 'SLACK_REQUESTED_BY=%s\n' "$REQ" >> "$GITHUB_ENV"
           echo "Slack requester: '${REQ:-<none>}' (empty or non-user-id -> standing mention list)"
 

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -136,12 +136,11 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.ARENA_AUTOMATION_SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ vars.ARENA_AUTOMATION_SLACK_CHANNEL }}
       SLACK_MENTIONS: ${{ vars.ARENA_AUTOMATION_SLACK_MENTIONS }}
-      # WHO a `--mention` notification pages: the requester ALONE when the run came in through
-      # Slack, else SLACK_MENTIONS (see `automation.slack.resolve_mentions`). Set from the poller's
-      # forwarded input on the Slack path; the "Resolve the Slack requester" step below fills it
-      # from the seed commit on the label-triggered path, where inputs are absent. A value that is
-      # not a Slack user id is dropped by `resolve_mentions`, so the standing list takes over.
-      SLACK_REQUESTED_BY: ${{ inputs.requested_by }}
+      # SLACK_REQUESTED_BY (WHO a `--mention` pings: the requester ALONE when the run came in
+      # through Slack, else SLACK_MENTIONS - see `automation.slack.resolve_mentions`) is NOT declared
+      # here on purpose: a job-level `env:` entry can shadow a value a step writes to $GITHUB_ENV, so
+      # the label-triggered path (no input) could never override an empty default. The "Resolve the
+      # Slack requester" step is the SINGLE writer instead, reading the input at step scope.
       # Values the ${secret:NAME} references in the LLM_PROXY_HEADERS variable resolve to.
       # Named LLM_PROXY_* because they are gateway configuration, not automation config;
       # they are NOT companions in the resolve_proxy_config sense (that check names only
@@ -203,15 +202,19 @@ jobs:
 
       - name: Resolve the Slack requester (input first, else the seed commit)
         # WHO the terminal / needs-human Slack pings page: the person who asked, ALONE, when the
-        # request came through Slack. The poller forwards their id as the `requested_by` input (job
-        # env above); a by-hand label add carries no input, so fall back to the `requested_by:`
-        # trailer the poller - and a by-hand seed - writes into the branch's seed commit.
-        # `automation.slack.resolve_mentions` re-validates, so a value that is not a Slack user id
-        # (e.g. a GitHub login on a by-hand seed) is dropped there and the standing SLACK_MENTIONS
-        # list takes over. Exported to $GITHUB_ENV so every later `slack ... --mention` step sees it.
+        # request came through Slack. The poller forwards their id as the `requested_by` input (read
+        # at STEP scope below); a by-hand label add carries no input, so fall back to the
+        # `requested_by:` trailer the poller - and a by-hand seed - writes into the branch's seed
+        # commit. This step is the SINGLE writer of SLACK_REQUESTED_BY (no job-level default to be
+        # shadowed by, or to shadow, this $GITHUB_ENV write), so every later `slack ... --mention`
+        # step sees exactly this value. `automation.slack.resolve_mentions` re-validates it, so a
+        # value that is not a Slack user id (e.g. a GitHub login on a by-hand seed) is dropped there
+        # and the standing SLACK_MENTIONS list takes over.
+        env:
+          INPUT_REQUESTED_BY: ${{ inputs.requested_by }}
         run: |
           set -uo pipefail
-          REQ="${SLACK_REQUESTED_BY:-}"
+          REQ="${INPUT_REQUESTED_BY:-}"
           if [ -z "$REQ" ]; then
             # Newest-first, capped: the seed is the branch's oldest commit ahead of base and the
             # only one carrying the trailer, so the first match is it; -n 50 bounds the log walk.

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -40,6 +40,14 @@ on:
         description: "what triggered it (e.g. slack); informational only"
         required: false
         default: manual
+      requested_by:
+        description: >-
+          Slack user id of the requester, forwarded by the poller. When set, the terminal /
+          needs-human Slack pings page them ALONE instead of the standing SLACK_MENTIONS list.
+          Empty on a by-hand label add or a manual run (no Slack identity); a value that is not a
+          Slack user id is ignored and the standing list takes over.
+        required: false
+        default: ""
       route:
         description: >-
           transport for EVERY openrouter/openai call this run makes -- the candidate's probes
@@ -128,6 +136,12 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.ARENA_AUTOMATION_SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ vars.ARENA_AUTOMATION_SLACK_CHANNEL }}
       SLACK_MENTIONS: ${{ vars.ARENA_AUTOMATION_SLACK_MENTIONS }}
+      # WHO a `--mention` notification pages: the requester ALONE when the run came in through
+      # Slack, else SLACK_MENTIONS (see `automation.slack.resolve_mentions`). Set from the poller's
+      # forwarded input on the Slack path; the "Resolve the Slack requester" step below fills it
+      # from the seed commit on the label-triggered path, where inputs are absent. A value that is
+      # not a Slack user id is dropped by `resolve_mentions`, so the standing list takes over.
+      SLACK_REQUESTED_BY: ${{ inputs.requested_by }}
       # Values the ${secret:NAME} references in the LLM_PROXY_HEADERS variable resolve to.
       # Named LLM_PROXY_* because they are gateway configuration, not automation config;
       # they are NOT companions in the resolve_proxy_config sense (that check names only
@@ -186,6 +200,25 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - run: uv python install "$(cat .python-version)"
       - run: uv sync --dev --locked
+
+      - name: Resolve the Slack requester (input first, else the seed commit)
+        # WHO the terminal / needs-human Slack pings page: the person who asked, ALONE, when the
+        # request came through Slack. The poller forwards their id as the `requested_by` input (job
+        # env above); a by-hand label add carries no input, so fall back to the `requested_by:`
+        # trailer the poller - and a by-hand seed - writes into the branch's seed commit.
+        # `automation.slack.resolve_mentions` re-validates, so a value that is not a Slack user id
+        # (e.g. a GitHub login on a by-hand seed) is dropped there and the standing SLACK_MENTIONS
+        # list takes over. Exported to $GITHUB_ENV so every later `slack ... --mention` step sees it.
+        run: |
+          set -uo pipefail
+          REQ="${SLACK_REQUESTED_BY:-}"
+          if [ -z "$REQ" ]; then
+            # Newest-first, capped: the seed is the branch's oldest commit ahead of base and the
+            # only one carrying the trailer, so the first match is it; -n 50 bounds the log walk.
+            REQ="$(git log -n 50 --format=%B | sed -nE 's/^requested_by:[[:space:]]*//p' | head -1 | tr -d '[:space:]')"
+          fi
+          printf 'SLACK_REQUESTED_BY=%s\n' "$REQ" >> "$GITHUB_ENV"
+          echo "Slack requester: '${REQ:-<none>}' (empty or non-user-id -> standing mention list)"
 
       - name: Parse candidate model from PR title
         id: parse

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -156,7 +156,7 @@ jobs:
             echo "opened PR #${PR_NUM} for ${SLUG} (${PR_URL})"
             gh workflow run integrate-model.yml -R "$REPO" --ref "$BASE_REF" \
               -f pr="$PR_NUM" -f head_ref="$BRANCH" -f model="$SLUG" -f source=slack \
-              -f route="$ROUTE" || return 1
+              -f route="$ROUTE" -f requested_by="$REQUESTER" || return 1
             echo "dispatched integrate-model.yml for PR #${PR_NUM} (${SLUG})"
             # Confirm in the requester's own thread, WITH the PR link (the poll-step reply was
             # posted before the PR existed; the engine's progress thread is a separate root).

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -381,7 +381,7 @@ The requester's Slack user id reaches the run two ways, both covered by one reso
   commit.
 
 The value crossed a repo boundary and comes back OUT as a mention, so `resolve_mentions`
-re-validates it against the Slack user-id shape (`^[UW][A-Z0-9]{4,}$`): a by-hand seed that named a
+re-validates it against the Slack user-id shape (`^[UW][A-Z0-9]{8,}$`, prefix + at least eight): a by-hand seed that named a
 GitHub login rather than a Slack id is dropped, and the standing list takes over. This mirrors the
 eval orchestrator's `resolve_mentions`, which pages the eval requester the same way, and the two
 notifiers share the `SLACK_REQUESTED_BY` variable name on purpose.

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -305,7 +305,7 @@ cleanly, and a Slack failure never fails the job.
 |---|---|---|
 | `ARENA_AUTOMATION_SLACK_BOT_TOKEN` | secret | bot `xoxb-` token; needs `chat:write` + `channels:history` (history read is what finds the root), and the bot must be a member of the channel |
 | `ARENA_AUTOMATION_SLACK_CHANNEL` | variable | target channel id (both the notifier's thread root and the poller's scan target) |
-| `ARENA_AUTOMATION_SLACK_MENTIONS` | variable | comma-separated Slack user ids to @mention; empty -> no mention |
+| `ARENA_AUTOMATION_SLACK_MENTIONS` | variable | comma-separated Slack user ids to @mention on terminal / needs-human notifications. The FALLBACK list: a run requested through Slack pages its requester alone instead (see _Who gets pinged_). Empty -> no mention |
 | `ARENA_AUTOMATION_SLACK_ALLOWED_USERS` | variable | (poller) comma-separated Slack user-ids allowed to trigger an integration; empty -> anyone in the channel (channel membership is the authz gate, since GitHub only ever sees the bot) |
 | `ARENA_AUTOMATION_SLACK_ICON_OVERRIDE` | variable | OPTIONAL. JSON map from icon ROLE to the emoji the workspace uploaded, e.g. `{"observe_started":":tf-observe-started:","needs_human":":tf-needs-human:"}`. Unset (the default) leaves every message with its default icon |
 
@@ -347,8 +347,8 @@ as a workflow annotation. `icons.icon()` itself still raises (a role is written 
 so a bad one is a bug here, not a user typo), but the CLI wrappers catch everything and exit 0,
 which would otherwise turn that raise into a silently dropped notification on a green step.
 
-Messages are emoji-prefixed and carry the run URL. `mention` = the `SLACK_MENTIONS` users are
-pinged (terminal / attention states only):
+Messages are emoji-prefixed and carry the run URL. `mention` = a ping is appended so someone gets
+pulled in (terminal / attention states only):
 
 | When | Mention |
 |---|---|
@@ -358,8 +358,33 @@ pinged (terminal / attention states only):
 | unexpected failure (catch-all, deduped against the handled cases above) | yes |
 
 The fork-reject path is PR-comment-only (a fork `pull_request` run gets no secrets, so the
-notifier cannot post). `SLACK_MENTIONS` pings fire on the terminal and error notifications so a
-human is alerted when the PR needs review or the run broke.
+notifier cannot post). The pings fire on the terminal and error notifications so a human is alerted
+when the PR needs review or the run broke.
+
+### Who gets pinged
+
+A channel where every integration pages the same standing list is a channel people mute, and a
+muted ping defeats the one message that needs one. So `automation.slack.resolve_mentions` pages the
+**requester alone** when the run came in through Slack, and falls back to the standing
+`ARENA_AUTOMATION_SLACK_MENTIONS` list only for runs nobody asked for through Slack (a by-hand label
+add, or a manual `workflow_dispatch`, has a GitHub actor but no Slack identity). Unset on both is not
+an error: the message still posts, just without a ping.
+
+The requester's Slack user id reaches the run two ways, both covered by one resolver step
+(_Resolve the Slack requester_):
+
+- **Slack path**: the poller (`slack-integrate.yml`) already holds the requester for the allowlist
+  check and forwards it as the `requested_by` workflow input to `integrate-model.yml`, which exports
+  it as `SLACK_REQUESTED_BY`.
+- **Label path**: a human adding `automation:integrate-model` carries no input, so the step reads
+  the `requested_by:` trailer the poller (and a by-hand seed commit) writes into the branch's seed
+  commit.
+
+The value crossed a repo boundary and comes back OUT as a mention, so `resolve_mentions`
+re-validates it against the Slack user-id shape (`^[UW][A-Z0-9]{4,}$`): a by-hand seed that named a
+GitHub login rather than a Slack id is dropped, and the standing list takes over. This mirrors the
+eval orchestrator's `resolve_mentions`, which pages the eval requester the same way, and the two
+notifiers share the `SLACK_REQUESTED_BY` variable name on purpose.
 
 ## Prompts (`tools/automation/src/automation/prompts/`)
 

--- a/tools/automation/src/automation/slack.py
+++ b/tools/automation/src/automation/slack.py
@@ -107,11 +107,21 @@ def build_mention_suffix(raw: str | None) -> str:
 #: notifier reads the SAME variable name, so one mental model covers both flows.
 REQUESTED_BY_ENV = "SLACK_REQUESTED_BY"
 
-#: What a Slack user id looks like (``U…``/``W…``, upper-case alphanumeric). The requester value
-#: originates in a Slack message's platform metadata and crosses a repo boundary as a workflow
-#: input before being rendered back INTO Slack as a mention - so anything that does not look like a
-#: user id is dropped rather than interpolated, and the configured list takes over.
-_SLACK_USER_ID_RE = re.compile(r"^[UW][A-Z0-9]{4,}$")
+#: What a Slack user id looks like (``U…``/``W…``, upper-case alphanumeric, at least nine chars).
+#: The requester value originates in a Slack message's platform metadata and crosses a repo boundary
+#: as a workflow input before being rendered back INTO Slack as a mention - so anything that does not
+#: look like a user id is dropped rather than interpolated, and the configured list takes over. The
+#: ``{8,}`` floor (prefix + >= 8) matches Slack's real id length; a looser ``{4,}`` would pass a
+#: stray short token like ``UAAAA`` through the trust boundary.
+_SLACK_USER_ID_RE = re.compile(r"^[UW][A-Z0-9]{8,}$")
+
+
+def _normalize_user_id(value: str | None) -> str:
+    """Strip the wrappings a Slack id arrives in (surrounding space, ``<@U…>``, ``@U…``).
+
+    One place so :func:`looks_like_slack_user_id` and :func:`resolve_mentions` accept the exact same
+    shapes as they grow (e.g. ``<@U…|display-name>``) instead of drifting apart by hand."""
+    return (value or "").strip().strip("<>").lstrip("@")
 
 
 def looks_like_slack_user_id(value: str | None) -> bool:
@@ -119,7 +129,7 @@ def looks_like_slack_user_id(value: str | None) -> bool:
 
     Tolerates the ``<@U…>`` / ``@U…`` wrappings the same as the mention builders, so a caller can
     validate a raw input before it is interpolated back into a ping."""
-    return bool(_SLACK_USER_ID_RE.match((value or "").strip().strip("<>").lstrip("@")))
+    return bool(_SLACK_USER_ID_RE.match(_normalize_user_id(value)))
 
 
 def resolve_mentions() -> str | None:
@@ -136,7 +146,7 @@ def resolve_mentions() -> str | None:
     rather than trusted: anything not shaped like a Slack user id is dropped and the list takes
     over. Unset is not an error - a run with nobody to page still posts, just without a ping.
     """
-    requester = (os.environ.get(REQUESTED_BY_ENV) or "").strip().strip("<>").lstrip("@")
+    requester = _normalize_user_id(os.environ.get(REQUESTED_BY_ENV))
     if requester:
         if looks_like_slack_user_id(requester):
             return requester

--- a/tools/automation/src/automation/slack.py
+++ b/tools/automation/src/automation/slack.py
@@ -22,8 +22,11 @@ Subcommands (the ``slack`` sub-app):
       re-trigger reuses the existing root instead of opening a new one.
   reply --channel <id> --pr <N> --text <msg> [--model <name>] [--mention]
       Reply into the PR's thread (creating the root first if missing). With
-      ``--mention`` the configured ``SLACK_MENTIONS`` users are appended so they
-      get pinged; used for the terminal / needs-human / error notifications.
+      ``--mention`` a ping is appended so someone gets pulled in; used for the
+      terminal / needs-human / error notifications. WHO is paged is
+      :func:`resolve_mentions`: the Slack requester alone when the run came in
+      through the channel (``SLACK_REQUESTED_BY``), else the standing
+      ``SLACK_MENTIONS`` list.
 """
 
 from __future__ import annotations
@@ -96,6 +99,53 @@ def build_mention_suffix(raw: str | None) -> str:
     ids = build_mention_prefix(raw).strip()
     sep = chr(10) * 2  # blank line so the reviewer line sits below the links
     return f"{sep}Notifying: {ids}" if ids else f"{sep}No reviewers configured to notify."
+
+
+#: The Slack user who ASKED for this integration, when the request came in through the channel. The
+#: poller (slack-integrate.yml) already has it as ``requester`` for the allowlist check; it forwards
+#: it as the ``requested_by`` workflow input, and the workflow exports it here. The engine's eval
+#: notifier reads the SAME variable name, so one mental model covers both flows.
+REQUESTED_BY_ENV = "SLACK_REQUESTED_BY"
+
+#: What a Slack user id looks like (``U…``/``W…``, upper-case alphanumeric). The requester value
+#: originates in a Slack message's platform metadata and crosses a repo boundary as a workflow
+#: input before being rendered back INTO Slack as a mention - so anything that does not look like a
+#: user id is dropped rather than interpolated, and the configured list takes over.
+_SLACK_USER_ID_RE = re.compile(r"^[UW][A-Z0-9]{4,}$")
+
+
+def looks_like_slack_user_id(value: str | None) -> bool:
+    """Whether *value* is shaped like a Slack user id (``U…``/``W…``).
+
+    Tolerates the ``<@U…>`` / ``@U…`` wrappings the same as the mention builders, so a caller can
+    validate a raw input before it is interpolated back into a ping."""
+    return bool(_SLACK_USER_ID_RE.match((value or "").strip().strip("<>").lstrip("@")))
+
+
+def resolve_mentions() -> str | None:
+    """Who a terminal / needs-human notification pages: the requester alone, else the standing list.
+
+    A channel where every integration pages the same standing list is a channel people mute, and a
+    muted ping defeats the one message that needs one. So when the run was requested through Slack,
+    the requester ALONE is paged - it is their integration, and everyone else can read the thread
+    without being pulled into it. ``SLACK_MENTIONS`` stays the fallback for runs nobody asked for
+    through Slack (a by-hand label add or a manual ``workflow_dispatch`` has a GitHub actor but no
+    Slack identity).
+
+    The requester value crossed a repo boundary as a workflow input, so it is re-validated here
+    rather than trusted: anything not shaped like a Slack user id is dropped and the list takes
+    over. Unset is not an error - a run with nobody to page still posts, just without a ping.
+    """
+    requester = (os.environ.get(REQUESTED_BY_ENV) or "").strip().strip("<>").lstrip("@")
+    if requester:
+        if _SLACK_USER_ID_RE.match(requester):
+            return requester
+        # Bounded like every other interpolated value: this is a raw input echoed into a log.
+        _log(
+            f"ignoring malformed {REQUESTED_BY_ENV} value {requester[:80]!r}; "
+            "using the configured list"
+        )
+    return os.environ.get("SLACK_MENTIONS")
 
 
 def append_footer(text: str, pr_comment: str = "", pr_url: str = "", run_url: str = "") -> str:
@@ -275,7 +325,7 @@ def cmd_reply(
         _prefixed(role, text), pr_comment=pr_comment, pr_url=pr_url, run_url=run_url
     )
     if mention:
-        body += build_mention_suffix(os.environ.get("SLACK_MENTIONS"))
+        body += build_mention_suffix(resolve_mentions())
     if not _post_message(channel, body, token, thread_ts=thread_ts):
         _note_failure("could not post the thread reply")
 

--- a/tools/automation/src/automation/slack.py
+++ b/tools/automation/src/automation/slack.py
@@ -138,7 +138,7 @@ def resolve_mentions() -> str | None:
     """
     requester = (os.environ.get(REQUESTED_BY_ENV) or "").strip().strip("<>").lstrip("@")
     if requester:
-        if _SLACK_USER_ID_RE.match(requester):
+        if looks_like_slack_user_id(requester):
             return requester
         # Bounded like every other interpolated value: this is a raw input echoed into a log.
         _log(

--- a/tools/automation/tests/test_slack.py
+++ b/tools/automation/tests/test_slack.py
@@ -207,7 +207,8 @@ class TestResolveMentions:
     )
     def test_junk_is_dropped_not_rendered(self, junk, monkeypatch):
         """The value crossed from Slack metadata through a workflow input and comes back OUT as a
-        mention - anything not shaped like a user id must fall back to the list, never interpolate."""
+        mention - anything not shaped like a user id must fall back to the list, never interpolate.
+        """
         monkeypatch.setenv("SLACK_MENTIONS", "U_OPS1")
         monkeypatch.setenv(slack.REQUESTED_BY_ENV, junk)
         assert slack.resolve_mentions() == "U_OPS1"

--- a/tools/automation/tests/test_slack.py
+++ b/tools/automation/tests/test_slack.py
@@ -13,6 +13,14 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _no_ambient_mention_env(monkeypatch):
+    """`resolve_mentions` reads the environment, so a developer shell exporting either variable
+    would leak into every test. Scrub both; the tests that WANT one set it explicitly."""
+    monkeypatch.delenv(slack.REQUESTED_BY_ENV, raising=False)
+    monkeypatch.delenv("SLACK_MENTIONS", raising=False)
+
+
 class TestBuildRootText:
     def test_contains_match_tokens(self):
         text = slack.build_root_text("qwen/qwen3.6-plus", 42)
@@ -168,3 +176,88 @@ class TestMentionSuffix:
         assert slack.build_mention_suffix("") == expected
         assert slack.build_mention_suffix(None) == expected
         assert slack.build_mention_suffix(" , , ") == expected
+
+
+class TestResolveMentions:
+    """WHO a `--mention` notification pages: the Slack requester alone when the run came in through
+    the channel, else the standing `SLACK_MENTIONS` list (a by-hand label add / manual dispatch has
+    a GitHub actor but no Slack identity).
+    """
+
+    def test_the_requester_wins_over_the_standing_list(self, monkeypatch):
+        monkeypatch.setenv("SLACK_MENTIONS", "U_OPS1,U_OPS2")
+        monkeypatch.setenv(slack.REQUESTED_BY_ENV, "U0B1AN4QYMR")
+        assert slack.resolve_mentions() == "U0B1AN4QYMR"
+
+    def test_no_requester_keeps_the_standing_list(self, monkeypatch):
+        monkeypatch.setenv("SLACK_MENTIONS", "U_OPS1")
+        assert slack.resolve_mentions() == "U_OPS1"
+
+    def test_no_requester_and_no_list_is_none(self):
+        assert slack.resolve_mentions() is None
+
+    def test_a_wrapped_id_is_normalised(self, monkeypatch):
+        # The poller hands over a bare id, but tolerate the mention-shaped forms the rest of the
+        # module already accepts.
+        monkeypatch.setenv(slack.REQUESTED_BY_ENV, "<@U0B1AN4QYMR>")
+        assert slack.resolve_mentions() == "U0B1AN4QYMR"
+
+    @pytest.mark.parametrize(
+        "junk", ["not-a-user", "u0lowercase", "U12", "rm -rf /", "U0B1 AN4QYMR", "*<!channel>*"]
+    )
+    def test_junk_is_dropped_not_rendered(self, junk, monkeypatch):
+        """The value crossed from Slack metadata through a workflow input and comes back OUT as a
+        mention - anything not shaped like a user id must fall back to the list, never interpolate."""
+        monkeypatch.setenv("SLACK_MENTIONS", "U_OPS1")
+        monkeypatch.setenv(slack.REQUESTED_BY_ENV, junk)
+        assert slack.resolve_mentions() == "U_OPS1"
+
+    def test_junk_with_no_list_is_none_not_the_junk(self, monkeypatch):
+        monkeypatch.setenv(slack.REQUESTED_BY_ENV, "not-a-user")
+        assert slack.resolve_mentions() is None
+
+
+class TestLooksLikeSlackUserId:
+    @pytest.mark.parametrize("good", ["U0B1AN4QYMR", "W12345", "<@U0B1AN4QYMR>", "@U12345"])
+    def test_accepts_user_ids_and_their_wrappings(self, good):
+        assert slack.looks_like_slack_user_id(good) is True
+
+    @pytest.mark.parametrize("bad", ["", None, "not-a-user", "u0lowercase", "U12", "U1,U2"])
+    def test_rejects_everything_else(self, bad):
+        assert slack.looks_like_slack_user_id(bad) is False
+
+
+class TestTheReplyPingsTheRequesterAlone:
+    """`cmd_reply --mention` must page the resolved audience, not the raw standing list."""
+
+    def _capture(self, monkeypatch):
+        sent: list[str] = []
+        monkeypatch.setattr(slack, "_ready", lambda *_a, **_k: "tok")
+        monkeypatch.setattr(slack, "_find_or_create_root", lambda *_a, **_k: "1.0")
+        monkeypatch.setattr(
+            slack,
+            "_post_message",
+            lambda ch, text, tok, thread_ts=None: sent.append(text) or "9.9",
+        )
+        return sent
+
+    def test_requester_present_pages_them_alone(self, monkeypatch):
+        sent = self._capture(monkeypatch)
+        monkeypatch.setenv("SLACK_MENTIONS", "U_OPS1,U_OPS2")
+        monkeypatch.setenv(slack.REQUESTED_BY_ENV, "U0B1AN4QYMR")
+        slack.cmd_reply("C", 7, "needs a human.", "m", mention=True)
+        assert "<@U0B1AN4QYMR>" in sent[0]
+        assert "U_OPS1" not in sent[0] and "U_OPS2" not in sent[0]
+
+    def test_no_requester_pages_the_standing_list(self, monkeypatch):
+        sent = self._capture(monkeypatch)
+        monkeypatch.setenv("SLACK_MENTIONS", "U_OPS1,U_OPS2")
+        slack.cmd_reply("C", 7, "needs a human.", "m", mention=True)
+        assert "<@U_OPS1>" in sent[0] and "<@U_OPS2>" in sent[0]
+
+    def test_without_mention_no_one_is_paged(self, monkeypatch):
+        sent = self._capture(monkeypatch)
+        monkeypatch.setenv("SLACK_MENTIONS", "U_OPS1")
+        monkeypatch.setenv(slack.REQUESTED_BY_ENV, "U0B1AN4QYMR")
+        slack.cmd_reply("C", 7, "observe started", "m", mention=False)
+        assert "U0B1AN4QYMR" not in sent[0] and "U_OPS1" not in sent[0]

--- a/tools/automation/tests/test_slack.py
+++ b/tools/automation/tests/test_slack.py
@@ -219,13 +219,19 @@ class TestResolveMentions:
 
 
 class TestLooksLikeSlackUserId:
-    @pytest.mark.parametrize("good", ["U0B1AN4QYMR", "W12345", "<@U0B1AN4QYMR>", "@U12345"])
+    @pytest.mark.parametrize("good", ["U0B1AN4QYMR", "W012345678", "<@U0B1AN4QYMR>", "@U012345678"])
     def test_accepts_user_ids_and_their_wrappings(self, good):
         assert slack.looks_like_slack_user_id(good) is True
 
     @pytest.mark.parametrize("bad", ["", None, "not-a-user", "u0lowercase", "U12", "U1,U2"])
     def test_rejects_everything_else(self, bad):
         assert slack.looks_like_slack_user_id(bad) is False
+
+    @pytest.mark.parametrize("short", ["UAAAA", "U1234", "W1234567", "<@U1234>"])
+    def test_rejects_ids_shorter_than_slacks_real_length(self, short):
+        # The `{8,}` floor (prefix + >= 8) guards the trust boundary: a stray short `U…`/`W…`
+        # token must not pass and get interpolated back into a `<@…>` ping.
+        assert slack.looks_like_slack_user_id(short) is False
 
 
 class TestTheReplyPingsTheRequesterAlone:


### PR DESCRIPTION
## What

The model auto-integration Slack notifier now pages the **requester alone** when the run came in through the channel, instead of always pinging the standing `ARENA_AUTOMATION_SLACK_MENTIONS` list. This mirrors the eval orchestrator's `resolve_mentions`, which already pages the eval requester the same way.

A channel where every integration pages the same standing list is a channel people mute, and a muted ping defeats the one message that needs one. The standing list stays as the fallback for runs nobody asked for through Slack (a by-hand label add or a manual `workflow_dispatch` has a GitHub actor but no Slack identity).

## How

- **`tools/automation/src/automation/slack.py`** — add `resolve_mentions()`, `REQUESTED_BY_ENV` (`SLACK_REQUESTED_BY`, the same variable name the eval notifier uses), `looks_like_slack_user_id()`, and the `_SLACK_USER_ID_RE` guard. `cmd_reply(..., mention=True)` now pings `resolve_mentions()` rather than the raw `SLACK_MENTIONS`.
- **`.github/workflows/integrate-model.yml`** — new `requested_by` input; `SLACK_REQUESTED_BY` job env from it; a "Resolve the Slack requester" step that fills it from the branch's seed-commit `requested_by:` trailer on the label-triggered path (where inputs are absent).
- **`.github/workflows/slack-integrate.yml`** — the poller forwards `-f requested_by="$REQUESTER"` (it already holds the id for the allowlist check).
- **`docs/AUTO_INTEGRATION.md`** — a _Who gets pinged_ section.

The requester value crosses a repo boundary as a workflow input and comes back OUT as a mention, so `resolve_mentions` re-validates it against the Slack user-id shape (`^[UW][A-Z0-9]{4,}$`): a by-hand seed that named a GitHub login rather than a Slack id is dropped and the standing list takes over. Unset on both is not an error, the message still posts without a ping.

## Tests

`tools/automation/tests/test_slack.py` gains `TestResolveMentions`, `TestLooksLikeSlackUserId`, and `TestTheReplyPingsTheRequesterAlone` (requester wins, junk is dropped not rendered, `cmd_reply` pings the resolved audience). Local runs:

```
tools/automation/tests            304 passed
tests/canonical/test_integrate_model_bucket_flow.py + test_icons.py + test_gateway_catalog.py   108 passed
ruff format + ruff check          clean
```

No behavior change for a repo with no requester in scope (empty input, no trailer): it still pages `SLACK_MENTIONS` exactly as before.

Companion skill update (tasks repo): toloka-partners/tolokaforge-tasks#315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

### CI note

`test-smoke` fails on one pre-existing test, `tests/canonical/test_models_wheel_replay.py::test_replay_matches_baseline` — the self-referential snapshot flake tracked in #1234. It is unrelated to this change: the branch adds **zero** `integrate:` commits (the only thing that test enumerates), it passes locally on this branch and on `origin/main` alike, and it is the same failure the recent integration PRs (#1449, #1161, #1277) merged past and #1475 later regenerated. Regenerating the snapshot here would be scope creep against a moving target. Every other check (lint, hygiene-review, CodeQL, Analyze, wheel-install-gate) is green.

### Review addressed (independent review, 2026-09-07)

- **Precedence-independent requester resolution** (`fix` commit): dropped the job-level `SLACK_REQUESTED_BY` default so a job-`env:` entry can neither shadow nor be shadowed by the resolver step's `$GITHUB_ENV` write. The step now reads `inputs.requested_by` at step scope and is the single writer, so the label-triggered fallback pages the requester as intended regardless of runner env precedence. The Slack-dispatch path was already precedence-safe.
- **`looks_like_slack_user_id` now has a production caller**: `resolve_mentions` validates through it instead of an inline regex.
- Reviewer confirmed: the resolver step runs before every `--mention` call; the `^[UW][A-Z0-9]{4,}$` guard drops GitHub logins / shell metacharacters / `<!channel>` before interpolation; `tr -d '[:space:]']` prevents any multi-line `$GITHUB_ENV` injection from a commit body; the seed-commit walk cannot mis-page a stranger on the public `main`; and no behavior change when no requester is in scope.
