### PR TITLE
fix(testing): freeze models-wheel replay snapshot at a cutoff SHA

### DIFF
--- a/tests/canonical/_models_wheel_replay/git_walk.py
+++ b/tests/canonical/_models_wheel_replay/git_walk.py
@@ -58,8 +58,15 @@ def _run_git(repo_root: Path, args: list[str]) -> str:
     return result.stdout
 
 
-def enumerate_integration_commits(repo_root: Path) -> list[IntegrationCommit]:
-    """Return every ``^integrate: `` commit reachable from ``HEAD``.
+def enumerate_integration_commits(
+    repo_root: Path, until: str | None = None
+) -> list[IntegrationCommit]:
+    """Return every ``^integrate: `` commit reachable from ``until`` (defaults to ``HEAD``).
+
+    Passing ``until`` walks history reachable from that revision instead of
+    ``HEAD``, so the caller can freeze the replay at a known cutoff and stop
+    the metric from drifting on every new integration. Any revision ``git
+    log`` accepts is valid; missing revisions raise ``RuntimeError``.
 
     Chronological, oldest-first (``git log --reverse`` over committer-
     date order). One ``git log`` call across all matching commits, plus
@@ -81,7 +88,7 @@ def enumerate_integration_commits(repo_root: Path) -> list[IntegrationCommit]:
         repo_root,
         [
             "log",
-            "HEAD",
+            until or "HEAD",
             f"--grep={_SUBJECT_PREFIX}",
             f"--format={_LOG_FORMAT}",
             "--reverse",

--- a/tests/canonical/test_models_wheel_replay.py
+++ b/tests/canonical/test_models_wheel_replay.py
@@ -3,7 +3,19 @@ under the ADR-0030 widened design.
 
 See ADR-0030 § "What success looks like" for the target this test
 reports against, and ``tools/automation/src/automation/bucket_classifier.py``
-for the Bucket A / Bucket B classifier."""
+for the Bucket A / Bucket B classifier.
+
+The snapshot check is frozen at ``_FROZEN_UNTIL`` — a fixed historical
+cutoff — so the metric measures **classifier stability** rather than
+history size. A new integration commit does not touch the snapshot;
+only a classifier-logic change (a new bucket rule, a moved allow-list
+path) does. See issue #1531. The live report (the ``print`` below)
+still walks to ``HEAD`` so every CI run surfaces the current acceptance-
+target fraction on the log.
+
+Bump ``_FROZEN_UNTIL`` when the classifier logic changes and the
+historical postures should reflect that; regenerate the snapshot in
+the same commit."""
 
 from __future__ import annotations
 
@@ -23,9 +35,16 @@ pytestmark = pytest.mark.canonical
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
+#: Frozen replay cutoff — last integration commit at the time the freeze
+#: landed. New integrations reachable from ``HEAD`` above this SHA are
+#: reported live (see the ``print`` in :func:`test_replay_matches_baseline`)
+#: but do not enter the pinned snapshot. Bump only for a classifier-logic
+#: change (see the module docstring).
+_FROZEN_UNTIL = "e8f837d760111f70afeb41a5dbe6302cdc3c7f99"
 
-def _build_metric() -> dict[str, Any]:
-    commits = enumerate_integration_commits(_REPO_ROOT)
+
+def _build_metric(until: str | None = None) -> dict[str, Any]:
+    commits = enumerate_integration_commits(_REPO_ROOT, until=until)
     integrations = []
     for c in commits:
         cls = classify_paths(c.touched)
@@ -50,16 +69,19 @@ def _build_metric() -> dict[str, Any]:
 
 
 def test_replay_matches_baseline(canon_snapshot) -> None:
-    """Live replay of every ``^integrate: `` commit reachable from HEAD."""
-    metric = _build_metric()
-    # Captured by pytest and surfaced on the CI log; carries the current
-    # metric even on green so passing runs still report the counts.
+    """Snapshot check is frozen at ``_FROZEN_UNTIL``; live report walks to ``HEAD``."""
+    frozen = _build_metric(until=_FROZEN_UNTIL)
+    live = _build_metric()
+    # Captured by pytest and surfaced on the CI log; carries the LIVE
+    # (HEAD) counts so passing runs still report the current fraction.
     print(
-        f"\n[models-wheel replay]  Bucket A: {metric['bucket_a_count']}  |  "
-        f"Bucket B: {metric['bucket_b_count']}  |  "
-        f"total: {len(metric['integrations'])}"
+        f"\n[models-wheel replay]  live@HEAD  Bucket A: {live['bucket_a_count']}  |  "
+        f"Bucket B: {live['bucket_b_count']}  |  "
+        f"total: {len(live['integrations'])}    "
+        f"(snapshot frozen at {_FROZEN_UNTIL[:12]}: "
+        f"A={frozen['bucket_a_count']} B={frozen['bucket_b_count']})"
     )
-    canon_snapshot("models_wheel_replay").assert_match(metric, "metric.json")
+    canon_snapshot("models_wheel_replay").assert_match(frozen, "metric.json")
 
 
 def test_git_walk_returns_expected_shape() -> None:


### PR DESCRIPTION
## Summary

- Freezes the `test_models_wheel_replay` snapshot at a cutoff SHA so new integration commits no longer force a snapshot bump.
- Keeps the CI live-report print walking `HEAD` so every run still surfaces current Bucket A/B counts.
- **Unsticks `main`, which is currently red on the canonical lane** following the merge of #1511.

Closes #1531.

## Why

The acceptance test walked every `^integrate: ` commit reachable from `HEAD` and pinned the full result to `metric.json`. Any integration commit invalidated the snapshot, including the commit that would regenerate it — the natural edit → regenerate → commit → push flow is the non-convergent one.

Concrete cost since the test was introduced in #1058 (2026-08-12):

| PR | Snapshot bumped in-PR? |
|---|---|
| #1160 google/gemini-3.7-flash | ✅ |
| #1161 x-ai/grok-4.6 | ✅ |
| #1277 z-ai/glm-5.3 | ❌ — cleanup in #1475 |
| #1449 anthropic/claude-fable-5.1 | ❌ — cleanup in #1475 |
| #1511 openai/gpt-6-astra | ❌ — main red at time of writing |

60% CI-friction rate on a class of PR the automation is designed to make routine.

## What

The docstring's stated intent is "fraction of auto-integrations that would land Bucket A under the ADR-0030 widened design". An exact-match snapshot of the whole commit list is stricter than that intent needs, and the strictness is what makes the test self-referential.

Two components split:

- **Snapshot check** freezes the git walk at `_FROZEN_UNTIL = e8f837d7…` (the last integration commit at the time of this PR — #1449, anthropic/claude-fable-5.1). Measures classifier stability — a snapshot diff means the bucket logic changed, not that a new integration landed. New integrations do not touch the snapshot.
- **Live report** (the `print`) still walks `HEAD` so CI still surfaces the current acceptance-target fraction on every run. Example output on this branch:

  ```
  [models-wheel replay]  live@HEAD  Bucket A: 4  |  Bucket B: 8  |  total: 12    (snapshot frozen at e8f837d76011: A=4 B=7)
  ```

`enumerate_integration_commits` takes an optional `until` argument that `git log` accepts as any revision; `None` preserves the existing HEAD default so the live-report call is unchanged.

Bumping `_FROZEN_UNTIL` is now a deliberate act tied to a classifier-logic change (a new bucket rule, a moved allow-list path), not a per-integration chore. The existing snapshot on `main` already matches the frozen state at `_FROZEN_UNTIL` so no snapshot regeneration is needed to land this fix.

## Out of scope

Sibling test `test_harness_registry_replay.py` has the same design bug (#1234) and the same fix pattern applies. Left in place to keep this PR small and #1234's options open for the harness owner; happy to bundle in a follow-up.

## Test plan

- [x] `uv run pytest tests/canonical/test_models_wheel_replay.py -v` — green locally on this branch (which includes #1511's `openai/gpt-6-astra` commit above the cutoff).
- [x] Same test on `origin/main` without this fix — red (`bucket_b_count: 8 != 7`), matches CI signal.
- [ ] test-smoke green on this PR.