### PR TITLE
fix(grader): audit accounted_keys on GraderCompositeDispatch — restore ledger-parity with runner-side (#1398)

### DIFF
--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -366,6 +366,21 @@ The refusal is client-side (fires before any gRPC round-trip) so the
 misconfiguration surfaces without a network hop, and the trial books as
 ungradeable rather than as an agent failure.
 
+### Runtime ledger
+
+The grader-service composite dispatcher records the same
+`accounted_keys` ledger the runner does. Each `_grade_*_block` helper
+returns the `KeyAccountingRecord` fragment for its component;
+`_run_composite` merges every fragment, runs
+`audit_accounted_keys(grading_config, accounted_keys)` before the fold,
+and forwards `audit.skip_notes` to
+`CompositeFold.finalise(ledger_skip_notes=...)`. A populated scored key
+neither evaluated nor recorded as a skip raises `GradingFailedError`
+naming the key; the `Grade` handler translates that into
+`GradeResponse(success=false)` — the wire shape a runner-side ledger
+failure produces. See [`docs/GRADING.md` § The runtime ledger](GRADING.md#the-runtime-ledger)
+for the shared contract.
+
 ### A component the config declared that produced no verdict
 
 The grader-service composite dispatcher shares one fold rule with the

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -108,12 +108,13 @@ fails the suite instead of failing every `GradeTrial` that carries it.
 
 ### The runtime ledger
 
-The canonical suite guards the *config models*; the runner guards each individual
-request. Through the component phase `GradeTrial` records, at every point an
-evaluator is invoked or deliberately skipped, which author key that call accounts
-for. Each record is a `KeyAccountingRecord` — an outcome of `EVALUATED` or
-`SKIPPED` plus, for a skip, the `detail` a task author reads. It then subtracts
-those records from the scored keys the request's grading config actually populated
+The canonical suite guards the *config models*; both composite dispatchers
+guard each individual request. Through the component phase each dispatcher
+records, at every point an evaluator is invoked or deliberately skipped, which
+author key that call accounts for. Each record is a `KeyAccountingRecord` — an
+outcome of `EVALUATED` or `SKIPPED` plus, for a skip, the `detail` a task
+author reads. It then subtracts those records from the scored keys the request's
+grading config actually populated
 ([`tolokaforge/runner/grading_ledger.py`](../tolokaforge/runner/grading_ledger.py)).
 A non-empty remainder means a key would have scored nothing, so the RPC returns
 `success=False` naming each key and the runner evaluator its manifest entry
@@ -1924,10 +1925,10 @@ defaults silently under proto3 (`withheld == False` from an older runner,
 matching every pack that never declared `on_missing: withhold`).
 
 **A trial whose timeline carries no events leaves the component unscored.** Every
-constraint would otherwise be answered by evidence the trial does not have. The
-runner records that as a skip against each declared constraint kind, and — since
-a component the pack configures but nothing scores is not folded in — a pack
-weighted entirely on `trace_checks` fails such a trial rather than passing it.
+constraint would otherwise be answered by evidence the trial does not have. Both
+composite dispatchers record that as a skip against each declared constraint kind,
+and — since a component the pack configures but nothing scores is not folded in —
+a pack weighted entirely on `trace_checks` fails such a trial rather than passing it.
 The guard against a trial that *does* carry events but should not have counted as
 work is `transcript_rules.min_assistant_turns`, which is a separate declaration.
 

--- a/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/expected_grade.json
+++ b/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/expected_grade.json
@@ -1,0 +1,23 @@
+{
+  "binary_pass": true,
+  "components": {
+    "custom_checks": -1.0,
+    "llm_judge": -1.0,
+    "state_checks": -1.0,
+    "trace_checks": -1.0,
+    "transcript_rules": -1.0
+  },
+  "criterion_results": [],
+  "custom_checks": [],
+  "judge_status": "JUDGE_STATUS_UNSPECIFIED",
+  "reasons": "custom_checks skipped: custom checks not enabled | no component was configured and no weight names one, so nothing was scored and nothing was owed",
+  "score": 1.0,
+  "state_diff_json": "",
+  "trace_checks": [],
+  "trace_checks_summary": {
+    "failed_gate_ids": [],
+    "gate_failed": false,
+    "paths": [],
+    "winning_path": ""
+  }
+}

--- a/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/grading.yaml
+++ b/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/grading.yaml
@@ -1,0 +1,3 @@
+weights: {}
+custom_checks:
+  enabled: false

--- a/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/parity.yaml
+++ b/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/parity.yaml
@@ -1,0 +1,3 @@
+accepted_divergences: []
+refusal_mode: false
+judge_script: []

--- a/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/task.yaml
+++ b/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/task.yaml
@@ -1,0 +1,23 @@
+task_id: custom_checks_disabled_ledger_skip
+name: Ledger SKIP-with-note lane — custom_checks disabled
+category: test
+description: |
+  Isolates the runtime ledger's ``SKIPPED``-with-note path end-to-end. The
+  grading config populates ``custom_checks`` with ``enabled: false`` and
+  declares no other component; the audit records a
+  ``CUSTOM_CHECKS_DISABLED_SKIP`` for the populated key, the fold treats
+  ``custom_checks`` as unrequested (opt-in gate returns false), the
+  free-pass verdict produces a Grade, and
+  ``CompositeFold.finalise(ledger_skip_notes=...)`` renders the skip note
+  ``"custom_checks skipped: custom checks not enabled"`` verbatim in
+  ``Grade.reasons`` on both dispatch substrates.
+adapter_type: tau
+schema_version: 1.0.0
+system_prompt: You are a test assistant.
+agent_tools: []
+user_tools: []
+initial_state:
+  tables:
+    users:
+      - id: u1
+        name: Alice

--- a/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/trial.yaml
+++ b/tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/trial.yaml
@@ -1,0 +1,3 @@
+trial_id: custom_checks_disabled_ledger_skip:0
+termination_reason: agent_done
+llm_messages: []

--- a/tests/canonical/test_grader_ledger_parity.py
+++ b/tests/canonical/test_grader_ledger_parity.py
@@ -96,7 +96,7 @@ def _task_description() -> TaskDescription:
     )
 
 
-def test_llm_judge_no_messages_records_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_llm_judge_no_messages_records_skip() -> None:
     """A populated ``llm_judge`` block with an empty transcript files
     :data:`NO_JUDGE_MESSAGES_SKIP` under :data:`LLM_JUDGE_KEY` so the audit
     reads a ``SKIPPED`` record instead of an unaccounted-key error.
@@ -132,7 +132,7 @@ def test_llm_judge_no_messages_records_skip(monkeypatch: pytest.MonkeyPatch) -> 
     assert judge_gate_failed is False
 
 
-def test_custom_checks_disabled_records_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_custom_checks_disabled_records_skip() -> None:
     """A ``custom_checks: {enabled: false}`` block files
     :data:`CUSTOM_CHECKS_DISABLED_SKIP` under :data:`CUSTOM_CHECKS_KEY` so
     the audit reads a ``SKIPPED`` record.

--- a/tests/canonical/test_grader_ledger_parity.py
+++ b/tests/canonical/test_grader_ledger_parity.py
@@ -1,0 +1,164 @@
+"""Seam-level ledger parity locks for :class:`GraderCompositeDispatch`.
+
+Two canonical locks that fail loud on future removal of the grader-side
+recording sites for the ``llm_judge`` and ``custom_checks`` blocks. The
+byte-parity pack under ``grader_parity_baselines/custom_checks_disabled_ledger_skip/``
+locks the wire-serialised Grade end-to-end; these locks catch drift at the
+Python-level helper granularity where an implementer touches individual sites.
+
+Both drive the private ``_grade_*_block`` helper directly against a stub
+substrate and assert the returned ledger-accounting dict carries the expected
+:class:`KeyAccountingRecord` for the skip branch. Direct-helper calls stay
+below :meth:`GraderCompositeDispatch._run_composite`'s fold so a populated
+``llm_judge`` block with no messages — a shape the fold refuses because
+``component_requested`` treats a populated ``llm_judge`` as requested — still
+exercises the recording site the audit reads.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.grading.grade_components import CompositeGradeComponents
+from tolokaforge.core.models import KeyAccounting, ModelConfig
+from tolokaforge.grader.composite_dispatch import GraderCompositeDispatch
+from tolokaforge.runner.grading_ledger import (
+    CUSTOM_CHECKS_DISABLED_SKIP,
+    CUSTOM_CHECKS_KEY,
+    LLM_JUDGE_KEY,
+    NO_JUDGE_MESSAGES_SKIP,
+)
+from tolokaforge.runner.models import (
+    Criterion,
+    LLMJudgeConfig,
+    Rubric,
+    RunnerGradingConfig,
+    RunnerInitialStateConfig,
+    TaskDescription,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+_TRIAL_ID = "seam-lock:0"
+_JUDGE_MODEL = ModelConfig(provider="openai", name="gpt-4o-mini", temperature=0.0)
+_STATE: dict[str, list[dict[str, Any]]] = {"users": [{"id": "u1", "name": "Alice"}]}
+
+
+class _StubSubstrate:
+    """Constant-snapshot substrate reaching every accessor without a network hop."""
+
+    def initial_state(self) -> dict[str, Any]:
+        return dict(_STATE)
+
+    def final_state(self) -> dict[str, Any]:
+        return dict(_STATE)
+
+    def final_state_stable(self) -> dict[str, Any]:
+        return dict(_STATE)
+
+    def filesystem_root(self):  # type: ignore[no-untyped-def]
+        return None
+
+    def filesystem_state(self) -> dict[str, str] | None:
+        return None
+
+    def db_reader(self) -> Any:
+        reader = MagicMock()
+        reader.get_state = lambda tables=None: dict(_STATE)
+        reader.query = lambda jp: {"results": []}
+        return reader
+
+    def knowledge_search(self) -> Any:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+def _task_description() -> TaskDescription:
+    return TaskDescription.model_validate(
+        {
+            "task_id": "seam-lock-task",
+            "name": "ledger-parity seam-lock fixture",
+            "category": "test",
+            "description": "seam-lock fixture",
+            "adapter_type": "tau",
+            "system_prompt": "You are a test assistant.",
+            "initial_state": RunnerInitialStateConfig(tables=_STATE).model_dump(),
+            "agent_tools": [],
+            "user_tools": [],
+            "grading": {},
+        }
+    )
+
+
+def test_llm_judge_no_messages_records_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A populated ``llm_judge`` block with an empty transcript files
+    :data:`NO_JUDGE_MESSAGES_SKIP` under :data:`LLM_JUDGE_KEY` so the audit
+    reads a ``SKIPPED`` record instead of an unaccounted-key error.
+
+    Locks the grader-side recording site :meth:`GraderCompositeDispatch._grade_llm_judge_block`
+    that :meth:`_run_composite` merges into ``accounted_keys`` before the audit
+    fires. A refactor that silently strips this site would surface as this
+    helper returning an empty dict, and the audit would then raise
+    :class:`GradingFailedError` on the unaccounted ``llm_judge`` key.
+    """
+    dispatch = GraderCompositeDispatch(logger=MagicMock())
+    llm_judge = LLMJudgeConfig(
+        rubric=Rubric(
+            criteria=[Criterion(id="ok", description="Task completed", kind="binary", weight=1.0)]
+        )
+    )
+
+    _, judge_status, judge_gate_failed, accounted = dispatch._grade_llm_judge_block(
+        trial_id=_TRIAL_ID,
+        llm_judge_config=llm_judge,
+        judge_model_config=_JUDGE_MODEL,
+        llm_messages=[],
+        substrate=_StubSubstrate(),  # type: ignore[arg-type]
+        initial_state_schemas=[],
+        id_fields={},
+        unstable_fields=set(),
+        components=CompositeGradeComponents(),
+    )
+
+    assert accounted == {LLM_JUDGE_KEY: NO_JUDGE_MESSAGES_SKIP}
+    assert accounted[LLM_JUDGE_KEY].outcome is KeyAccounting.SKIPPED
+    assert judge_status.name == "UNSPECIFIED"
+    assert judge_gate_failed is False
+
+
+def test_custom_checks_disabled_records_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``custom_checks: {enabled: false}`` block files
+    :data:`CUSTOM_CHECKS_DISABLED_SKIP` under :data:`CUSTOM_CHECKS_KEY` so
+    the audit reads a ``SKIPPED`` record.
+
+    Locks the grader-side recording site :meth:`GraderCompositeDispatch._grade_custom_checks_block`
+    that :meth:`_run_composite` merges into ``accounted_keys`` before the audit
+    fires. A refactor that silently strips this site would surface as this
+    helper returning an empty dict, and the audit would then raise
+    :class:`GradingFailedError` on the unaccounted ``custom_checks`` key.
+    """
+    dispatch = GraderCompositeDispatch(logger=MagicMock())
+    grading_config = RunnerGradingConfig(
+        weights={},
+        custom_checks={"enabled": False},
+    )
+    task = _task_description()
+
+    _, _, accounted = dispatch._grade_custom_checks_block(
+        trial_id=_TRIAL_ID,
+        grading_config=grading_config,
+        task_description=task,
+        llm_messages=[],
+        substrate=_StubSubstrate(),  # type: ignore[arg-type]
+        artifacts_dir=None,
+        components=CompositeGradeComponents(),
+    )
+
+    assert accounted == {CUSTOM_CHECKS_KEY: CUSTOM_CHECKS_DISABLED_SKIP}
+    assert accounted[CUSTOM_CHECKS_KEY].outcome is KeyAccounting.SKIPPED

--- a/tests/canonical/test_grader_parity_reference.py
+++ b/tests/canonical/test_grader_parity_reference.py
@@ -123,6 +123,7 @@ _COMPOSITE_PACKS: list[ParityPackSpec] = [
     ParityPackSpec("state_plus_judge", "gradable"),
     ParityPackSpec("all_four_no_hash", "gradable"),
     ParityPackSpec("hash_and_all_four", "refusal"),
+    ParityPackSpec("custom_checks_disabled_ledger_skip", "gradable"),
 ]
 _COMPOSITE_PARITY_PACK_IDS: list[str] = [
     spec.name for spec in _COMPOSITE_PACKS if spec.snapshot_kind == "gradable"

--- a/tests/canonical/test_grader_parity_reference.py
+++ b/tests/canonical/test_grader_parity_reference.py
@@ -478,11 +478,11 @@ def test_regression_sim_leg_divergence_names_the_component(
     Runs the runner leg with production :func:`grade_trace_checks`, then
     monkeypatches the composite module's binding to a stub whose result leaves
     ``trace_checks`` unscored while the config still declares it. The grader
-    leg's fold refuses the trial (``resolve_uncounted_fold`` catches the
-    declared-but-unscored shape) and the parity harness sees a
-    :class:`GradingFailedError` naming the missing component — the same
-    seam-named signal a between-legs code divergence produces, now surfacing
-    fail-loud through the refusal path rather than through a score diff.
+    leg's ``audit_accounted_keys`` catches the declared-but-unaccounted shape
+    and the parity harness sees a :class:`GradingFailedError` naming the
+    missing component — the same seam-named signal a between-legs code
+    divergence produces, surfacing fail-loud through the ledger-audit refusal
+    path rather than through a score diff.
     """
     pack = load_parity_pack(_BASELINES_ROOT / "all_four_no_hash")
     run_via_runner_rpc(pack, monkeypatch=monkeypatch)

--- a/tolokaforge/core/grading/kinds/composite.py
+++ b/tolokaforge/core/grading/kinds/composite.py
@@ -23,8 +23,10 @@ Two-mode dispatch:
    ``grade_transcript_rules`` / ``grade_trace_checks`` /
    ``build_judge_state_diff`` + ``grade_llm_judge`` /
    ``grade_custom_checks``; folds; returns a :class:`Grade` byte-parity
-   with the runner-side ``_grade_trial_async`` dispatch (minus hash +
-   accounted-keys ledger, which are runner-only surfaces).
+   with the runner-side ``_grade_trial_async`` dispatch (minus hash
+   grading, which needs runner DB write access, and minus the accounted-keys
+   ledger, which the two live dispatchers own — the offline recompute
+   here trusts a bundle a live dispatcher already audited).
 
 **Hash refusal.** A task declaring ``state_checks.hash_enabled`` is
 refused up-front with the same fragment

--- a/tolokaforge/grader/composite_dispatch.py
+++ b/tolokaforge/grader/composite_dispatch.py
@@ -20,7 +20,7 @@ the run-scoped :class:`~tolokaforge.runner.models.RunnerGradingConfig` /
 :class:`~tolokaforge.core.models.ModelConfig` from JSON, builds a fresh
 substrate against ``dispatch.runner_substrate_address``, drives the composite
 functions in the same order the runner's ``_grade_trial_async`` does (minus
-hash / accounted-keys ledger / verdict compose), and folds the results into
+hash / verdict compose), and folds the results into
 a :class:`~tolokaforge.core.models.Grade`. Hash grading is refused (the
 substrate is read-only). ``SubstrateUnreachableError`` is translated to
 :class:`~tolokaforge.core.trial_grader.GradingFailedError` so the trial books
@@ -42,10 +42,12 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 from tolokaforge.core.grading import composite
+from tolokaforge.core.grading.checks_helpers import custom_checks_enabled
 from tolokaforge.core.grading.checks_interface import CheckResult
 from tolokaforge.core.grading.composite_fold import CompositeFold, CompositeFoldResult
 from tolokaforge.core.grading.grade_components import CompositeGradeComponents
 from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
+from tolokaforge.core.grading.key_manifest import EVALUATED
 from tolokaforge.core.grading.substrate import SubstrateUnreachableError
 from tolokaforge.core.grading.tool_artifacts import extract_tool_artifacts
 from tolokaforge.core.grading.trace_checks import TraceChecksResult
@@ -72,6 +74,15 @@ from tolokaforge.core.plugin_registry import (
     load_transcript_rule_matcher,
 )
 from tolokaforge.core.trial_grader import GradingFailedError
+from tolokaforge.runner.grading_ledger import (
+    CUSTOM_CHECKS_DISABLED_SKIP,
+    CUSTOM_CHECKS_KEY,
+    HASH_DISABLED_SKIP,
+    LLM_JUDGE_KEY,
+    NO_JUDGE_MESSAGES_SKIP,
+    audit_accounted_keys,
+    hash_family_skip_accounting,
+)
 from tolokaforge.runner.models import (
     RunnerGradingConfig,
     TaskDescription,
@@ -84,6 +95,7 @@ if TYPE_CHECKING:
     from tolokaforge.core.grading.substrate import GradingSubstrate
     from tolokaforge.core.grading.transcript import TranscriptEvaluationResult
     from tolokaforge.core.logging import StructuredLogger
+    from tolokaforge.core.models import KeyAccountingRecord
     from tolokaforge.grader.service import GradeDispatch
 
 
@@ -244,7 +256,7 @@ class GraderCompositeDispatch:
         substrate: GradingSubstrate,
         artifacts_dir: Any,
     ) -> Grade:
-        """Mirror ``_grade_trial_async`` (runner) minus hash / accounted-keys ledger."""
+        """Mirror ``_grade_trial_async`` (runner) minus hash / verdict compose."""
         trial_id = dispatch.trial_id
         llm_messages: list[dict[str, Any]] = json.loads(dispatch.llm_messages_json or "[]")
         timeline = build_timeline_from_wire(
@@ -252,25 +264,35 @@ class GraderCompositeDispatch:
         )
         components = CompositeGradeComponents()
         state_checks_config = grading_config.state_checks
-        self._grade_state_checks_block(
-            trial_id=trial_id,
-            state_checks_config=state_checks_config,
-            substrate=substrate,
-            components=components,
+        accounted_keys: dict[str, KeyAccountingRecord] = {}
+        accounted_keys.update(
+            self._grade_state_checks_block(
+                trial_id=trial_id,
+                state_checks_config=state_checks_config,
+                substrate=substrate,
+                components=components,
+            )
         )
-        transcript_result = self._grade_transcript_rules_block(
+        transcript_result, transcript_accounting = self._grade_transcript_rules_block(
             trial_id=trial_id,
             config=grading_config.transcript_rules,
             timeline=timeline,
             components=components,
         )
+        accounted_keys.update(transcript_accounting)
         trace_result = self._grade_trace_checks_block(
             trial_id=trial_id,
             config=grading_config.trace_checks,
             timeline=timeline,
             components=components,
         )
-        judge_result, judge_status, judge_gate_failed = self._grade_llm_judge_block(
+        accounted_keys.update(trace_result.accounted_keys)
+        (
+            judge_result,
+            judge_status,
+            judge_gate_failed,
+            judge_accounting,
+        ) = self._grade_llm_judge_block(
             trial_id=trial_id,
             llm_judge_config=grading_config.llm_judge,
             judge_model_config=judge_model_config,
@@ -281,7 +303,12 @@ class GraderCompositeDispatch:
             unstable_fields=unstable_fields,
             components=components,
         )
-        custom_check_results, custom_reasons = self._grade_custom_checks_block(
+        accounted_keys.update(judge_accounting)
+        (
+            custom_check_results,
+            custom_reasons,
+            custom_accounting,
+        ) = self._grade_custom_checks_block(
             trial_id=trial_id,
             grading_config=grading_config,
             task_description=task_description,
@@ -290,6 +317,10 @@ class GraderCompositeDispatch:
             artifacts_dir=artifacts_dir,
             components=components,
         )
+        accounted_keys.update(custom_accounting)
+        audit = audit_accounted_keys(grading_config, accounted_keys)
+        if audit.error:
+            raise GradingFailedError(audit.error)
         fold_result = CompositeFold.finalise(
             components_dict=components.model_dump(),
             grading_config_dict=grading_config.model_dump(),
@@ -303,6 +334,7 @@ class GraderCompositeDispatch:
             trace_checks_result_dict=trace_result.model_dump(mode="json"),
             custom_checks_reasons=custom_reasons,
             judge_errored=judge_status is JudgeStatus.ERRORED,
+            ledger_skip_notes=audit.skip_notes,
         )
         components.llm_judge_score = fold_result.judge_component
         if fold_result.refusal:
@@ -323,12 +355,22 @@ class GraderCompositeDispatch:
         state_checks_config: Any,
         substrate: GradingSubstrate,
         components: CompositeGradeComponents,
-    ) -> None:
-        """Run the ``state_checks`` reads block and fold results onto ``components``."""
+    ) -> dict[str, KeyAccountingRecord]:
+        """Run the ``state_checks`` reads block and fold results onto ``components``.
+
+        Returns the ledger accounting for this block: ``hash_family_skip_accounting(
+        HASH_DISABLED_SKIP)`` for a task that populated ``state_checks`` without
+        enabling hash grading (mirroring :meth:`RunnerServiceImpl._grade_trial_async`
+        — hash grading itself is refused up front on the grader substrate), plus the
+        reads block's own :attr:`StateChecksReadResult.accounted_keys` when jsonpath
+        or db_probes ran.
+        """
         if not state_checks_config:
-            return
+            return {}
+        accounted: dict[str, KeyAccountingRecord] = {}
+        accounted.update(hash_family_skip_accounting(HASH_DISABLED_SKIP))
         if not (state_checks_config.jsonpath_checks or state_checks_config.db_probes):
-            return
+            return accounted
         state_reads = composite.grade_state_checks_reads(
             trial_id=trial_id,
             config=state_checks_config,
@@ -342,6 +384,8 @@ class GraderCompositeDispatch:
         if state_reads.db_probe_score is not None:
             components.db_probe_score = state_reads.db_probe_score
             components.db_probe_reasons = state_reads.db_probe_reasons or ""
+        accounted.update(state_reads.accounted_keys)
+        return accounted
 
     def _grade_transcript_rules_block(
         self,
@@ -350,11 +394,16 @@ class GraderCompositeDispatch:
         config: Any,
         timeline: Any,
         components: CompositeGradeComponents,
-    ) -> TranscriptEvaluationResult | None:
-        """Run the transcript-rules block and fold the pass / score onto ``components``."""
+    ) -> tuple[TranscriptEvaluationResult | None, dict[str, KeyAccountingRecord]]:
+        """Run the transcript-rules block and fold the pass / score onto ``components``.
+
+        Returns ``(result, accounted_keys)`` — the ledger accounting is the fragment
+        :func:`grade_transcript_rules` already returns; a block the config omitted
+        contributes no keys and no result.
+        """
         if not config:
-            return None
-        transcript_result, _accounting = composite.grade_transcript_rules(
+            return None, {}
+        transcript_result, accounted = composite.grade_transcript_rules(
             trial_id=trial_id,
             config=config,
             timeline=timeline,
@@ -364,7 +413,7 @@ class GraderCompositeDispatch:
         if transcript_result is not None:
             components.transcript_pass = transcript_result.passed
             components.transcript_score = transcript_result.score
-        return transcript_result
+        return transcript_result, accounted
 
     def _grade_trace_checks_block(
         self,
@@ -397,12 +446,15 @@ class GraderCompositeDispatch:
         substrate: GradingSubstrate,
         artifacts_dir: Any,
         components: CompositeGradeComponents,
-    ) -> tuple[list[CheckResult], str | None]:
+    ) -> tuple[list[CheckResult], str | None, dict[str, KeyAccountingRecord]]:
         """Run custom checks and fold the score onto ``components``.
 
-        Returns ``(custom_check_results, custom_reasons)`` for the reason
-        composition and Grade assembly downstream — the grader-side path
-        consumes :class:`CheckResult` directly, without a pb2 hop.
+        Returns ``(custom_check_results, custom_reasons, accounted_keys)`` for the
+        reason composition and Grade assembly downstream — the grader-side path
+        consumes :class:`CheckResult` directly, without a pb2 hop. ``accounted_keys``
+        records :data:`CUSTOM_CHECKS_KEY` as ``EVALUATED`` when the pack enabled
+        checks and :data:`CUSTOM_CHECKS_DISABLED_SKIP` when it wrote the block but
+        left ``enabled`` off (mirroring :meth:`RunnerServiceImpl._grade_trial_async`).
         """
         custom_score, custom_check_results, custom_reasons = composite.grade_custom_checks(
             trial_id=trial_id,
@@ -415,7 +467,14 @@ class GraderCompositeDispatch:
             logger=self._logger,
         )
         components.custom_checks_score = custom_score
-        return custom_check_results, custom_reasons
+        accounted: dict[str, KeyAccountingRecord] = {
+            CUSTOM_CHECKS_KEY: (
+                EVALUATED
+                if custom_checks_enabled(grading_config.custom_checks)
+                else CUSTOM_CHECKS_DISABLED_SKIP
+            )
+        }
+        return custom_check_results, custom_reasons, accounted
 
     def _grade_llm_judge_block(
         self,
@@ -429,18 +488,23 @@ class GraderCompositeDispatch:
         id_fields: dict[str, str | list[str]],
         unstable_fields: set[tuple[str, str]],
         components: CompositeGradeComponents,
-    ) -> tuple[JudgeResult | None, JudgeStatus, bool]:
+    ) -> tuple[JudgeResult | None, JudgeStatus, bool, dict[str, KeyAccountingRecord]]:
         """Load the rubric-evaluator seam, render the state diff, and grade.
 
-        Returns ``(judge_result, wire_judge_status, judge_gate_failed)``.
+        Returns ``(judge_result, wire_judge_status, judge_gate_failed, accounted_keys)``.
         A skipped judge (missing config or empty transcript) reports
         :attr:`JudgeStatus.UNSPECIFIED` with a ``None`` result; a runner
         errored status maps to :attr:`JudgeStatus.ERRORED`. On a
         completed run, ``components.llm_judge_score`` is populated when
-        the judge produced a numeric score.
+        the judge produced a numeric score. ``accounted_keys`` records
+        :data:`LLM_JUDGE_KEY` as ``EVALUATED`` when the judge ran, as
+        :data:`NO_JUDGE_MESSAGES_SKIP` when the config declared a judge but the
+        transcript is empty, and is empty when no ``llm_judge`` block was declared.
         """
-        if not (llm_judge_config and llm_messages):
-            return None, JudgeStatus.UNSPECIFIED, False
+        if llm_judge_config is None:
+            return None, JudgeStatus.UNSPECIFIED, False, {}
+        if not llm_messages:
+            return None, JudgeStatus.UNSPECIFIED, False, {LLM_JUDGE_KEY: NO_JUDGE_MESSAGES_SKIP}
         assert (
             judge_model_config is not None
         ), "llm_judge branch requires judge_model_config — validated above"
@@ -464,12 +528,13 @@ class GraderCompositeDispatch:
             state_diff=state_diff_text,
             logger=self._logger,
         )
+        accounted = {LLM_JUDGE_KEY: EVALUATED}
         if judge_result.status is JudgeRunStatus.ERRORED:
-            return judge_result, JudgeStatus.ERRORED, False
+            return judge_result, JudgeStatus.ERRORED, False, accounted
         judge_gate_failed = judge_result.gate_failed
         if judge_result.score is not None:
             components.llm_judge_score = judge_result.score
-        return judge_result, JudgeStatus.COMPLETED, judge_gate_failed
+        return judge_result, JudgeStatus.COMPLETED, judge_gate_failed, accounted
 
     def _build_rubric_evaluator(self, llm_judge_config: Any) -> RubricEvaluator:
         """Load the ``llm_judge`` rubric-evaluator seam with per-trial context.


### PR DESCRIPTION
## Summary

`GraderCompositeDispatch._run_composite` now accumulates `accounted_keys` from each of its five `_grade_*_block` helpers, runs `audit_accounted_keys(grading_config, accounted_keys)`, raises `GradingFailedError` on `audit.error`, and forwards `audit.skip_notes` to `CompositeFold.finalise(ledger_skip_notes=...)`. Fold-once discipline (AGENTS.md § "The runtime ledger" / `docs/GRADING.md`) is now byte-symmetric across the two live composite dispatchers — runner-side and grader-side.

Before this PR, the grader-side path silently skipped the audit. A pack whose grading config declared a component the trial didn't score would silently redistribute the missing weight across the remaining components on the grader-side path, while the runner-side path refused. Same input, different verdict — a correctness gap invisible to the existing 10 parity packs (all of which populate only EVALUATED-only keys).

Closes #1398.

## Design choices

| Decision | Rationale |
|---|---|
| Import `audit_accounted_keys` directly from `tolokaforge.runner.grading_ledger` | `.importlinter`'s `no-runner-reach-from-core-grading` explicitly whitelists that module (fences only `runner.service` + `runner.grading`). The grader package is free to import the shared audit helper — no plug-in seam or module move required. |
| Widen `_grade_*_block` return types with `dict[str, KeyAccountingRecord]` fragments | Each helper is the only site that knows its own recording semantics (EVALUATED / skip-record sentinel). Returning the fragment inline is cleaner than a side-channel dict passed through kwargs. Idiomatic tuple pattern with `{}` / `TraceChecksResult()` defaults — no `Optional[tuple]` sneaks in. |
| Substitute parity pack `custom_checks_disabled_ledger_skip` for the planned `rubric_only_no_messages` | The planned shape (llm_judge declared, transcript empty) is refused by `resolve_uncounted_fold` before the ledger fires, so no Grade ever reaches the wire and the skip note never lands in `Grade.reasons`. The substituted shape (composite pack, custom_checks disabled) locks the same audit → skip_notes → `CompositeFold.finalise(ledger_skip_notes=...)` seam end-to-end via a feasible fold path. |
| Seam-locks in `test_grader_ledger_parity.py` call `_grade_*_block` helpers directly | The `llm_judge` + no-messages path is refused by fold-refusal before `.grade()` returns; no observable Grade would surface the skip note. Direct-helper assertions preserve the plan's stated purpose of catching drift at the Python-level recording site. |
| Update `CompositeGraderKind` module docstring in the same commit | The pre-PR phrasing described the ledger as "runner-only"; with two live dispatchers now auditing, that's stale. New wording states the offline kind trusts an already-audited bundle — factual current-state, not scope creep. |
| No CHANGELOG entry | Wire types (`runner.proto` / `grader.proto`) untouched; `RunnerGradingConfig` / `Grade` / `GradeResponse` unchanged; all 5 `_grade_*_block` helpers are `_`-prefixed private. Existing 10 parity packs populate only EVALUATED-only keys, so their `Grade.reasons` is byte-identical after the fix. The user-visible change on packs that previously silently skipped is symmetric to what the runner-side already did — the silent skip was a bug, not a documented behaviour. |

## Test plan

- [x] New canonical parity pack `tests/canonical/grader_parity_baselines/custom_checks_disabled_ledger_skip/` — locks the SKIPPED-with-note lane end-to-end across both dispatchers. Added to `_COMPOSITE_PACKS` in `test_grader_parity_reference.py`.
- [x] New canonical file `tests/canonical/test_grader_ledger_parity.py` — two seam-level locks (`test_llm_judge_no_messages_records_skip`, `test_custom_checks_disabled_records_skip`) that fail loud on future removal of the `LLM_JUDGE` / `CUSTOM_CHECKS` recording sites.
- [x] `uv run --active lint-imports` → 10 contracts kept, 0 broken.
- [x] `uv run --active pytest tests/canonical/test_grader_parity_reference.py tests/canonical/test_grader_ledger_parity.py tests/canonical/test_grader_composite_dispatch.py -q` → 55 passed.
- [x] `uv run --active pytest tests/unit/grader/ tests/unit/grading/test_grading_ledger.py -q` → 53 passed.
- [x] Full canonical lane → 2059 passed, 19 skipped, 1 pre-existing failure (`test_harness_registry_replay.py`, baseline references rebased SHAs — same flake we've been tracking under #1234; regenerated for this branch's merge SHA if CI needs it).

## Reviewer coverage

- **reviewer-correctness** → APPROVE (byte-symmetric with runner-side; every recording site, tuple unpack, and error-shape verified against the runner counterpart).
- **reviewer-type-fit** → APPROVE (return-type widening idiomatic; `.importlinter` contracts kept; parity pack YAML shape matches sibling packs; canonical marker present).
- **reviewer-hygiene** → APPROVE WITH NITS (dropped 2 unused `monkeypatch` params + refreshed `test_regression_sim_leg_divergence_names_the_component` docstring — audit refusal replaces the old `resolve_uncounted_fold` path — in follow-up commit `1202d7ae`).

## Follow-ups

- **#1530** — CompositeGraderKind (offline dispatch) also skips `audit_accounted_keys`; P3. Under the shipping topology the offline kind is invoked to regrade bundles already produced by an audited dispatcher, so the gap is real only for hand-authored bundles. Kept out of #1398 to keep this PR bounded.