### PR TITLE
feat(runtime): probe BundleStore reachability at run-start (#1457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented in this file.
 ### Changed
 
 - **testing**: `tolokaforge.testing.adapters.AdapterGradingContractSuite` pins `grading_source` classmethod-dispatch parity — the class-level call (`type(adapter).grading_source(task, task_dir)`) must return the same `GradingSource` the instance-level call returns, matching the base contract's classmethod declaration and the invariant the delegation helper `grading_source_under_adapter` relies on. A third-party adapter that subclasses the suite and overrides `grading_source` as an instance method (rather than the classmethod the base declares) will fail the new invariant on upgrade; switch the override to `@classmethod` (or `@staticmethod` returning a value equal to the instance call). (#1393)
+- **grading**: `BundleStore` Protocol grew a required `probe(self) -> None` method — a cheap run-start reachability check the orchestrator calls once from `_validate_snapshot_mode_compatibility` when `grader.snapshot.enabled=true` (S3 `head_bucket`, LocalDisk sentinel write+delete). Out-of-tree plugins registered under the `tolokaforge.bundle_stores` entry-point group must implement it: an unupgraded plugin raises `AttributeError` at the call site, which the orchestrator wraps into an actionable `ValueError` with the `AttributeError` preserved on `__cause__` so plugin authors see the exact missing method. Migration one-liner for a plugin whose reachability cannot be cheaply asserted: `def probe(self) -> None: return None`. Operators whose credentials grant `s3:PutObject` but deny `s3:ListBucket` newly fail at run-start; inject a pre-built `client=` whose credentials pass `head_bucket` as the documented escape hatch. (#1457)
+
+### Fixed
+
+- **grading**: `grader.snapshot.enabled=true` with unreachable / mis-credentialled bundle stores (bad AWS creds on `S3BundleStore`, non-writeable `root_dir` on `LocalDiskBundleStore`) now aborts at run-start with an actionable `ValueError` naming the store type, its config, and a credential-source hint. Previously the failure surfaced silently as `SnapshotStatus.produce_failed` on every trial from `Conductor._produce_grade_bundle`'s per-trial `try/except`, leaving operators with N failed bundles instead of one clear message. (#1457)
 
 ### Perf
 

--- a/docs/DETACHED_GRADING.md
+++ b/docs/DETACHED_GRADING.md
@@ -56,9 +56,10 @@ Or with S3:
 
 **Startup gate.** The orchestrator refuses `snapshot.enabled=true` at run-start when:
 - The backend does not implement `RuntimeBackend.build_grade_bundle` (raises `NotImplementedError`), OR
-- `grader.expose_substrate` is `false` (the producer needs `SubstrateService` to compose reads).
+- `grader.expose_substrate` is `false` (the producer needs `SubstrateService` to compose reads), OR
+- the resolved bundle store's `probe()` fails — `LocalDiskBundleStore` sentinel write+delete under `<root_dir>/grade_bundles/`, `S3BundleStore` `head_bucket` on `bucket=` (a misconfigured store aborts the run before any trial produces, instead of recording `produce_failed` on every trial).
 
-An actionable error names both preconditions.
+An actionable error names the failing precondition.
 
 **Backend support** (out of the box):
 - `SharedStackRuntimeBackend` — supported.

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -757,7 +757,22 @@ class BundleStore(Protocol):
     def put(self, bundle_dir: Path) -> str: ...
     def get(self, uri: str, dest_dir: Path) -> Path: ...
     def close(self) -> None: ...
+    def probe(self) -> None: ...
 ```
+
+`probe()` is a cheap reachability check the orchestrator calls once at
+run-start when `grader.snapshot.enabled=true` (via
+`Orchestrator._validate_snapshot_mode_compatibility`): `LocalDiskBundleStore`
+writes and deletes a sentinel under `<root_dir>/grade_bundles/`;
+`S3BundleStore` issues a single `head_bucket` on `bucket=`. A failure
+raises `BundleStoreUnreachableError` naming the store's target and a
+credential-source hint, and the orchestrator wraps every probe exception
+(the shipped subclass, the missing-`boto3` `RuntimeError`, and the
+`AttributeError` an unupgraded out-of-tree plugin raises when its class
+has no `probe`) into one actionable `ValueError` with the underlying
+error preserved on `__cause__`. Passing the probe does not guarantee
+subsequent `put`/`get` calls succeed — probe covers reachability, not
+per-object durability.
 
 Implementations are discovered through the `tolokaforge.bundle_stores`
 entry-point group and resolved with

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -628,9 +628,10 @@ snapshot_status:
 
 **Startup validation.** `Orchestrator.__init__` refuses `snapshot.enabled=true` when:
 - the selected `RuntimeBackend` raises `NotImplementedError` from `build_grade_bundle` (opt-out signal), OR
-- `grader.expose_substrate=false` (snapshot mode composes reads via `SubstrateService` RPCs — the substrate must be exposed).
+- `grader.expose_substrate=false` (snapshot mode composes reads via `SubstrateService` RPCs — the substrate must be exposed), OR
+- the resolved bundle store's `probe()` fails — `LocalDiskBundleStore` sentinel write+delete under `<root_dir>/grade_bundles/`, `S3BundleStore` `head_bucket` on `bucket=` (bad AWS credentials, missing bucket, non-writable `root_dir`, or an out-of-tree plugin that has not upgraded to implement `probe()` all surface here as a single actionable `ValueError`).
 
-Both refusals name the failing condition and terminate the run before any trial produces.
+Each refusal names the failing condition and terminates the run before any trial produces.
 
 **Backend support.** Shipped backends: `SharedStackRuntimeBackend` + `PerTrialRuntimeBackend` implement `build_grade_bundle`; `InMemoryRuntimeBackend` opts out. External `tolokaforge.runtime_backends` plugins either implement the hook or opt out with a `NotImplementedError` stub — the Protocol is `@runtime_checkable` and the startup gate probes the backend at run-start.
 

--- a/tests/canonical/test_bundle_store_content_addressability.py
+++ b/tests/canonical/test_bundle_store_content_addressability.py
@@ -9,6 +9,7 @@ bundle.
 
 from __future__ import annotations
 
+import hashlib
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -123,3 +124,39 @@ def test_atomic_staging_leaves_no_partial_state_on_crash(
     assert (
         len(staging_dirs) == 1
     ), f"expected exactly one orphan per-worker .<digest>.<uuid4>.tmp/, got {staging_dirs}"
+
+
+def _tree_fingerprint(root: Path) -> dict[str, str]:
+    """Walk ``root``, hash every file's bytes, return ``{rel_posix: sha256_hex}``.
+
+    Deterministic across runs: keys are ``PurePosixPath.as_posix()`` and the
+    hash is a byte-for-byte read.
+    """
+    result: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        result[rel] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+def test_probe_then_put_byte_identical_to_put_alone(tmp_path: Path) -> None:
+    """``store.probe(); store.put(bundle)`` produces the same on-disk bytes as
+    ``store.put(bundle)`` alone — a probe must leave zero residue that could
+    pollute a subsequent put, or dedupe would silently break across
+    probed and non-probed stores."""
+    inputs = synthetic_inputs(tmp_path / "fixture")
+    bundle_a = _bundle_at(tmp_path, "bundle_a", inputs)
+    bundle_b = _bundle_at(tmp_path, "bundle_b", inputs)
+
+    store_probe = LocalDiskBundleStore(root_dir=tmp_path / "store_probe")
+    store_probe.probe()
+    store_probe.put(bundle_a)
+
+    store_plain = LocalDiskBundleStore(root_dir=tmp_path / "store_plain")
+    store_plain.put(bundle_b)
+
+    probe_tree = _tree_fingerprint(store_probe.root_dir / "grade_bundles")
+    plain_tree = _tree_fingerprint(store_plain.root_dir / "grade_bundles")
+    assert probe_tree == plain_tree

--- a/tests/unit/core/test_orchestrator_snapshot_startup_validation.py
+++ b/tests/unit/core/test_orchestrator_snapshot_startup_validation.py
@@ -1,23 +1,27 @@
 """Unit tests for ``Orchestrator._validate_snapshot_mode_compatibility``.
 
-Two gates fire at run-start when ``grader.snapshot.enabled=true``:
+Three gates fire at run-start when ``grader.snapshot.enabled=true``:
 
 - ``grader.expose_substrate`` must be ``True`` — the producer composes
   ``SubstrateService`` reads.
 - The resolved runtime backend must implement ``build_grade_bundle`` —
   probed with a fake trial id; ``NotImplementedError`` opts out.
+- The resolved bundle store must answer ``probe()`` — S3 ``head_bucket``,
+  LocalDisk sentinel write+delete. Any exception (including
+  ``AttributeError`` from an out-of-tree plugin that hasn't upgraded)
+  wraps into a single actionable :class:`ValueError`.
 
-Both fail loud at run-start with an actionable :class:`ValueError` so a
-snapshot-configured run does not silently record ``produce_failed`` for
-every trial.
+Each fails loud at run-start so a snapshot-configured run does not
+silently record ``produce_failed`` for every trial.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tolokaforge.core.grading.bundle_store import BundleStoreUnreachableError
 from tolokaforge.core.models import (
     EvaluationConfig,
     GraderConfig,
@@ -78,8 +82,10 @@ class TestSnapshotDisabled:
             )
         )
         backend = MagicMock()
-        orch._validate_snapshot_mode_compatibility(backend)
+        with patch.object(SnapshotBundleConfig, "build_store") as build_store:
+            orch._validate_snapshot_mode_compatibility(backend)
         backend.build_grade_bundle.assert_not_called()
+        build_store.assert_not_called()
 
 
 class TestExposeSubstrateGate:
@@ -173,3 +179,96 @@ class TestBackendCapabilityGate:
         backend.build_grade_bundle.side_effect = ValueError("unexpected backend bug")
         with pytest.raises(ValueError, match="unexpected backend bug"):
             orch._validate_snapshot_mode_compatibility(backend)
+
+
+class TestBundleStoreProbeGate:
+    """Third gate: the resolved bundle store must answer ``probe()``.
+
+    Every reachability failure — shipped-store ``BundleStoreUnreachableError``,
+    missing ``bundle-store-s3`` extra ``RuntimeError``, or a stale plugin
+    without ``probe()`` (``AttributeError``) — collapses into one
+    actionable :class:`ValueError`. The orchestrator wire-up catches
+    :class:`Exception` uniformly so the ``grader-detach`` import-linter
+    contract stays green with zero new imports on ``orchestrator.py``;
+    ``__cause__`` preserves the underlying diagnostic.
+    """
+
+    def _make_snapshot_orch(self, tmp_path) -> Orchestrator:
+        return Orchestrator(
+            _make_run_config(
+                snapshot=SnapshotBundleConfig(
+                    enabled=True,
+                    store=LocalDiskBundleStoreConfig(root_dir=str(tmp_path)),
+                ),
+                expose_substrate=True,
+            )
+        )
+
+    def _capability_present_backend(self) -> MagicMock:
+        backend = MagicMock()
+        backend.build_grade_bundle.side_effect = KeyError("trial not registered")
+        return backend
+
+    def test_refuses_when_store_probe_raises_unreachable(self, tmp_path) -> None:
+        orch = self._make_snapshot_orch(tmp_path)
+        backend = self._capability_present_backend()
+        store = MagicMock()
+        store.probe.side_effect = BundleStoreUnreachableError("bucket unreachable")
+        with patch.object(SnapshotBundleConfig, "build_store", return_value=store):
+            with pytest.raises(ValueError, match=r"grader\.snapshot\.store.*not reachable") as ei:
+                orch._validate_snapshot_mode_compatibility(backend)
+        assert "local_disk" in str(ei.value)
+        assert "bucket unreachable" in str(ei.value)
+        store.close.assert_called_once()
+
+    def test_accepts_when_store_probe_returns_cleanly(self, tmp_path) -> None:
+        orch = self._make_snapshot_orch(tmp_path)
+        backend = self._capability_present_backend()
+        store = MagicMock()
+        store.probe.return_value = None
+        with patch.object(SnapshotBundleConfig, "build_store", return_value=store):
+            orch._validate_snapshot_mode_compatibility(backend)
+        store.probe.assert_called_once()
+        store.close.assert_called_once()
+
+    def test_refuses_when_store_probe_raises_missing_extra_runtime_error(self, tmp_path) -> None:
+        """Missing ``bundle-store-s3`` extra: ``_boto3_client()`` raises
+        the install-hint ``RuntimeError``. The wrapper collapses it into
+        the same actionable ``ValueError`` shape (one re-raise contract)."""
+        orch = self._make_snapshot_orch(tmp_path)
+        backend = self._capability_present_backend()
+        store = MagicMock()
+        store.probe.side_effect = RuntimeError("S3BundleStore requires boto3.")
+        with patch.object(SnapshotBundleConfig, "build_store", return_value=store):
+            with pytest.raises(ValueError, match=r"grader\.snapshot\.store.*not reachable"):
+                orch._validate_snapshot_mode_compatibility(backend)
+
+    def test_refuses_when_unupgraded_plugin_lacks_probe_attribute(self, tmp_path) -> None:
+        """Regression lock: an out-of-tree plugin that upgraded tolokaforge
+        without adding ``probe()`` raises ``AttributeError`` at the
+        ``store.probe()`` call site. The wrapper turns that into the
+        same actionable ``ValueError``; ``__cause__`` preserves the
+        ``AttributeError`` so plugin authors see the missing method."""
+        orch = self._make_snapshot_orch(tmp_path)
+        backend = self._capability_present_backend()
+        store = MagicMock(spec=["put", "get", "close"])
+        with patch.object(SnapshotBundleConfig, "build_store", return_value=store):
+            with pytest.raises(ValueError, match=r"grader\.snapshot\.store.*not reachable") as ei:
+                orch._validate_snapshot_mode_compatibility(backend)
+        assert isinstance(ei.value.__cause__, AttributeError)
+        assert "probe" in str(ei.value.__cause__)
+
+    def test_store_probe_runs_after_backend_probe(self, tmp_path) -> None:
+        """Ordering: with a capability-present backend AND a store whose
+        probe raises, the orchestrator raises the store-probe ``ValueError``
+        (proving the backend probe ran first and passed, then the store
+        probe ran second and failed)."""
+        orch = self._make_snapshot_orch(tmp_path)
+        backend = self._capability_present_backend()
+        store = MagicMock()
+        store.probe.side_effect = BundleStoreUnreachableError("bucket unreachable")
+        with patch.object(SnapshotBundleConfig, "build_store", return_value=store):
+            with pytest.raises(ValueError, match=r"grader\.snapshot\.store.*not reachable"):
+                orch._validate_snapshot_mode_compatibility(backend)
+        backend.build_grade_bundle.assert_called_once()
+        store.probe.assert_called_once()

--- a/tests/unit/grading/test_bundle_store_local_disk.py
+++ b/tests/unit/grading/test_bundle_store_local_disk.py
@@ -1,13 +1,16 @@
 """Unit acceptance for ``LocalDiskBundleStore``.
 
 Covers the URI shape returned by ``put``, byte-identical round-trip
-through ``get``, and the three refusal contracts (non-empty destination,
-non-bundle scheme, wrong store name).
+through ``get``, the three refusal contracts (non-empty destination,
+non-bundle scheme, wrong store name), and the run-start ``probe()``
+contract (writable OK with zero residue / read-only ``root_dir``
+refused).
 """
 
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -15,6 +18,7 @@ import pytest
 from tolokaforge.core.grading.bundle import serialize_grade_bundle
 from tolokaforge.core.grading.bundle_store import (
     BundleNotFoundError,
+    BundleStoreUnreachableError,
     InvalidBundleURIError,
     LocalDiskBundleStore,
     build_bundle_uri,
@@ -152,3 +156,32 @@ def test_get_raises_bundle_not_found_for_partial_bundle(tmp_path: Path) -> None:
 
     with pytest.raises(BundleNotFoundError):
         store.get(partial_uri, dest)
+
+
+class TestLocalDiskBundleStoreProbe:
+    """Run-start reachability probe for ``LocalDiskBundleStore``.
+
+    A sentinel write+delete under ``_bundles_root`` covers the store's
+    single write path. Residue leakage would silently break dedupe; the
+    write-permission check surfaces stale mounts and read-only
+    filesystems at run-start rather than per-trial.
+    """
+
+    def test_probe_writable_root_returns_none_and_leaves_no_residue(self, tmp_path: Path) -> None:
+        store = LocalDiskBundleStore(root_dir=tmp_path / "ok")
+        assert store.probe() is None
+        assert list((tmp_path / "ok" / "grade_bundles").iterdir()) == []
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="chmod-based read-only enforcement is not honoured on Windows",
+    )
+    def test_probe_read_only_root_raises_unreachable(self, tmp_path: Path) -> None:
+        store = LocalDiskBundleStore(root_dir=tmp_path / "ro")
+        store._bundles_root.chmod(0o500)
+        try:
+            with pytest.raises(BundleStoreUnreachableError) as excinfo:
+                store.probe()
+            assert str(store.root_dir) in str(excinfo.value)
+        finally:
+            store._bundles_root.chmod(0o700)

--- a/tests/unit/grading/test_bundle_store_s3.py
+++ b/tests/unit/grading/test_bundle_store_s3.py
@@ -3,9 +3,11 @@
 Driven by ``botocore.stub.Stubber`` — no live S3, no ``moto`` dep.
 Locks the upload-order invariant (parts first, manifest LAST), the
 dedupe short-circuit on an existing manifest, the byte-identical
-round-trip through ``put``/``get``, the non-empty dest refusal, and
-proves that ``import tolokaforge.core.grading.bundle_store`` succeeds
-when ``boto3`` is not installed.
+round-trip through ``put``/``get``, the non-empty dest refusal,
+the run-start ``probe()`` contract (``head_bucket`` OK / denied /
+unreachable), and proves that ``import tolokaforge.core.grading.bundle_store``
+succeeds when ``boto3`` is not installed (with parity between the
+``put`` and ``probe`` install-hint ``RuntimeError``).
 """
 
 from __future__ import annotations
@@ -25,7 +27,10 @@ from tolokaforge.core.grading.bundle import (  # noqa: E402
     manifest_digest,
     serialize_grade_bundle,
 )
-from tolokaforge.core.grading.bundle_store import S3BundleStore  # noqa: E402
+from tolokaforge.core.grading.bundle_store import (  # noqa: E402
+    BundleStoreUnreachableError,
+    S3BundleStore,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -64,23 +69,32 @@ def _key(digest: str, rel: str) -> str:
 
 def test_lazy_boto3_import(tmp_path: Path) -> None:
     # Verify (a) bundle_store imports without boto3 present, and (b) instantiating
-    # S3BundleStore + calling put raises RuntimeError naming the install extra.
-    # Runs in a subprocess so sys.modules pollution can't leak into sibling tests
-    # (importlib.reload swaps class identities and breaks `pytest.raises` in
-    # downstream tests that captured the pre-reload class at collection time).
+    # S3BundleStore + calling put OR probe raises the same install-hint
+    # RuntimeError shape (parity: both entry points surface the missing extra
+    # identically). Runs in a subprocess so sys.modules pollution can't leak
+    # into sibling tests (importlib.reload swaps class identities and breaks
+    # `pytest.raises` in downstream tests that captured the pre-reload class
+    # at collection time).
     bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
     script = (
         "import sys\n"
         "sys.modules['boto3'] = None\n"
         "from tolokaforge.core.grading.bundle_store import S3BundleStore\n"
-        f"store = S3BundleStore(bucket='x')\n"
+        "store = S3BundleStore(bucket='x')\n"
         "try:\n"
         f"    store.put({str(bundle)!r})\n"
         "except RuntimeError as exc:\n"
         "    assert 'bundle-store-s3' in str(exc), str(exc)\n"
-        "    print('OK')\n"
         "else:\n"
         "    raise AssertionError('put did not raise RuntimeError')\n"
+        "probe_store = S3BundleStore(bucket='x')\n"
+        "try:\n"
+        "    probe_store.probe()\n"
+        "except RuntimeError as exc:\n"
+        "    assert 'bundle-store-s3' in str(exc), str(exc)\n"
+        "    print('OK')\n"
+        "else:\n"
+        "    raise AssertionError('probe did not raise RuntimeError')\n"
     )
     result = subprocess.run(
         [sys.executable, "-c", script],
@@ -240,3 +254,66 @@ class _StreamStub:
             if not chunk:
                 return
             yield chunk
+
+
+class TestS3BundleStoreProbe:
+    """Run-start reachability probe for ``S3BundleStore``.
+
+    A single ``head_bucket`` covers the whole store: credentials work,
+    bucket exists, and the caller can enumerate it. Every failure shape
+    surfaces as :class:`BundleStoreUnreachableError` naming the bucket
+    and the credential-source hint so operators know exactly which
+    lever to pull.
+    """
+
+    def test_probe_returns_none_when_head_bucket_ok(self) -> None:
+        client, stubber = _stubbed_client()
+        stubber.add_response(
+            "head_bucket",
+            service_response={},
+            expected_params={"Bucket": BUCKET},
+        )
+        stubber.activate()
+        try:
+            store = S3BundleStore(bucket=BUCKET, prefix=PREFIX, client=client)
+            assert store.probe() is None
+        finally:
+            stubber.deactivate()
+        stubber.assert_no_pending_responses()
+
+    def test_probe_raises_unreachable_on_client_error_403(self) -> None:
+        client, stubber = _stubbed_client()
+        stubber.add_client_error(
+            "head_bucket",
+            service_error_code="403",
+            service_message="Forbidden",
+            http_status_code=403,
+            expected_params={"Bucket": BUCKET},
+        )
+        stubber.activate()
+        try:
+            store = S3BundleStore(bucket=BUCKET, prefix=PREFIX, client=client)
+            with pytest.raises(BundleStoreUnreachableError) as excinfo:
+                store.probe()
+        finally:
+            stubber.deactivate()
+        message = str(excinfo.value)
+        assert BUCKET in message
+        assert "s3:ListBucket" in message
+        assert "boto3 default chain" in message
+
+    def test_probe_raises_unreachable_on_endpoint_connection_error(self) -> None:
+        from botocore.exceptions import EndpointConnectionError
+
+        client, _ = _stubbed_client()
+
+        def _boom(**_: Any) -> None:
+            raise EndpointConnectionError(endpoint_url="https://s3.example.invalid")
+
+        client.head_bucket = _boom  # type: ignore[method-assign]
+        store = S3BundleStore(bucket=BUCKET, prefix=PREFIX, client=client)
+        with pytest.raises(BundleStoreUnreachableError) as excinfo:
+            store.probe()
+        message = str(excinfo.value)
+        assert BUCKET in message
+        assert "EndpointConnectionError" in message

--- a/tests/unit/grading/test_bundle_store_s3.py
+++ b/tests/unit/grading/test_bundle_store_s3.py
@@ -78,7 +78,13 @@ def test_lazy_boto3_import(tmp_path: Path) -> None:
     bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
     script = (
         "import sys\n"
+        # Block BOTH boto3 and botocore so probe's local botocore.exceptions
+        # import can't succeed before _boto3_client() gets a chance to raise
+        # the friendly install-hint. Production `pip install tolokaforge`
+        # without the extra ships neither package.
         "sys.modules['boto3'] = None\n"
+        "sys.modules['botocore'] = None\n"
+        "sys.modules['botocore.exceptions'] = None\n"
         "from tolokaforge.core.grading.bundle_store import S3BundleStore\n"
         "store = S3BundleStore(bucket='x')\n"
         "try:\n"

--- a/tolokaforge/core/grading/bundle_store.py
+++ b/tolokaforge/core/grading/bundle_store.py
@@ -429,6 +429,7 @@ class S3BundleStore:
         self.client = None
 
     def probe(self) -> None:
+        client = self._boto3_client()
         from botocore.exceptions import (
             ClientError,
             EndpointConnectionError,
@@ -436,7 +437,6 @@ class S3BundleStore:
             PartialCredentialsError,
         )
 
-        client = self._boto3_client()
         try:
             client.head_bucket(Bucket=self.bucket)
         except ClientError as exc:

--- a/tolokaforge/core/grading/bundle_store.py
+++ b/tolokaforge/core/grading/bundle_store.py
@@ -61,6 +61,7 @@ __all__ = [
     "BundleNotFoundError",
     "BundleStore",
     "BundleStoreError",
+    "BundleStoreUnreachableError",
     "InvalidBundleURIError",
     "LocalDiskBundleStore",
     "S3BundleStore",
@@ -87,6 +88,20 @@ class BundleNotFoundError(BundleStoreError):
 
 class InvalidBundleURIError(BundleStoreError):
     """The URI is malformed, targets a different scheme, or names another store."""
+
+
+class BundleStoreUnreachableError(BundleStoreError):
+    """The store itself cannot be reached — bad credentials, missing bucket,
+    non-writeable ``root_dir``, network partition. Distinct from
+    :class:`BundleNotFoundError`, which means "this URI didn't resolve to a
+    stored bundle" on an otherwise-healthy store.
+
+    Tidy-not-load-bearing: the orchestrator's run-start wire-up catches
+    :class:`Exception` uniformly (see
+    :meth:`Orchestrator._validate_snapshot_mode_compatibility`), so no
+    production path branches on this subclass. It exists for semantic
+    clarity in the shipped stores' unit assertions and debug traces.
+    """
 
 
 def build_bundle_uri(store_name: str, digest: str) -> str:
@@ -174,6 +189,19 @@ class BundleStore(Protocol):
         """Release store-held resources. Idempotent."""
         ...
 
+    def probe(self) -> None:
+        """Verify the store is reachable and credentials/permissions work.
+
+        Raises :class:`BundleStoreUnreachableError` (or a subclass) with a
+        message naming the store's target and a credential-source hint.
+        Called once at run-start when ``grader.snapshot.enabled=true``.
+        Cheap: a single metadata read (S3 ``head_bucket``, LocalDisk
+        sentinel write+delete). NOT a substitute for ``put``/``get`` error
+        handling — a probe pass does not guarantee subsequent ``put``
+        calls succeed.
+        """
+        ...
+
 
 @dataclass
 class LocalDiskBundleStore:
@@ -231,10 +259,29 @@ class LocalDiskBundleStore:
     def close(self) -> None:
         return None
 
+    def probe(self) -> None:
+        sentinel = self._bundles_root / f".probe.{uuid.uuid4()}"
+        try:
+            sentinel.write_bytes(b"")
+            sentinel.unlink()
+        except OSError as exc:
+            raise BundleStoreUnreachableError(
+                f"LocalDiskBundleStore cannot write under root_dir={self.root_dir!s}: "
+                f"{exc.strerror or exc}. Verify the directory exists, is writeable "
+                "by the process user, and the filesystem has free space."
+            ) from exc
+
 
 _BOTO3_INSTALL_HINT = (
     "S3BundleStore requires boto3. Install the optional extra with "
     "'uv add tolokaforge[bundle-store-s3]' or 'pip install boto3'."
+)
+
+_S3_CREDENTIAL_HINT = (
+    "S3BundleStore credentials come from the boto3 default chain "
+    "(env vars / ~/.aws/credentials / EC2 or IRSA role) unless client= "
+    "was injected. Verify the bucket exists and the credential source "
+    "grants s3:ListBucket on it."
 )
 
 
@@ -263,7 +310,14 @@ class S3BundleStore:
     boto3 client with ``endpoint_url=`` / ``region_name=`` and pass it as
     ``client=``.
 
-    .. warning:: **Secrets bypass — tracked in #1457.**
+    :meth:`probe` runs at run-start (via
+    :meth:`Orchestrator._validate_snapshot_mode_compatibility` when
+    ``grader.snapshot.enabled=true``) and issues a single ``head_bucket``
+    to fail loud on unreachable buckets, missing credentials, or denied
+    permissions — a misconfigured store aborts the run at start rather
+    than silently recording ``produce_failed`` on every trial.
+
+    .. warning:: **Secrets bypass.**
        The auto-built client's credentials come from the boto3 default
        chain, bypassing :class:`~tolokaforge.secrets.SecretManager`. In
        production, either
@@ -272,8 +326,10 @@ class S3BundleStore:
        IRSA / EC2-role environments where the credential source is
        ambient infrastructure metadata, not an ``AWS_*`` env var.
        Passing ``AWS_*`` env vars to the process to feed the default
-       chain contradicts AGENTS.md § Secrets — single abstraction and
-       is refused in a follow-up (#1457).
+       chain contradicts AGENTS.md § Secrets — single abstraction; the
+       :class:`SecretManager` routing cleanup for
+       :meth:`_boto3_client` is tracked in `#1538
+       <https://github.com/Toloka/tolokaforge/issues/1538>`_.
     """
 
     bucket: str
@@ -371,3 +427,32 @@ class S3BundleStore:
         if callable(close):
             close()
         self.client = None
+
+    def probe(self) -> None:
+        from botocore.exceptions import (
+            ClientError,
+            EndpointConnectionError,
+            NoCredentialsError,
+            PartialCredentialsError,
+        )
+
+        client = self._boto3_client()
+        try:
+            client.head_bucket(Bucket=self.bucket)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            raise BundleStoreUnreachableError(
+                f"S3BundleStore cannot reach bucket={self.bucket!r} "
+                f"(prefix={self.prefix!r}): head_bucket failed with "
+                f"Error.Code={code!r}. {_S3_CREDENTIAL_HINT}"
+            ) from exc
+        except (
+            EndpointConnectionError,
+            NoCredentialsError,
+            PartialCredentialsError,
+        ) as exc:
+            raise BundleStoreUnreachableError(
+                f"S3BundleStore cannot reach bucket={self.bucket!r} "
+                f"(prefix={self.prefix!r}): {type(exc).__name__}: {exc}. "
+                f"{_S3_CREDENTIAL_HINT}"
+            ) from exc

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -1669,7 +1669,7 @@ class Orchestrator:
         """Refuse ``grader.snapshot.enabled=true`` on backends / configs that
         cannot honour it.
 
-        Runs once at run-start after the backend is resolved. Two guards:
+        Runs once at run-start after the backend is resolved. Three guards:
 
         * ``grader.expose_substrate`` must be ``True`` — the runtime
           backend composes bundle reads over the runner's
@@ -1684,6 +1684,13 @@ class Orchestrator:
           "backend is snapshot-capable" and every other exception
           re-raises so genuine bugs surface loudly here rather than
           per-trial at grade time.
+        * The resolved bundle store must be reachable — a single
+          ``store.probe()`` at run-start (S3 ``head_bucket`` /
+          LocalDisk sentinel write+delete) fails loud on bad credentials,
+          missing bucket, or non-writeable ``root_dir``. Without this,
+          a misconfigured store surfaces as ``produce_failed`` on every
+          trial inside :meth:`Conductor._produce_grade_bundle`'s
+          seam-contained ``try/except``.
 
         Actionable :class:`ValueError` names the failing condition and
         the concrete fix.
@@ -1724,6 +1731,27 @@ class Orchestrator:
             pass
         finally:
             shutil.rmtree(probe_dir, ignore_errors=True)
+        store = grader.snapshot.build_store()
+        try:
+            try:
+                store.probe()
+            except Exception as exc:
+                # Broad ``except`` is load-bearing: three failure families
+                # (``BundleStoreUnreachableError`` from a shipped store,
+                # ``RuntimeError`` from the missing ``bundle-store-s3``
+                # extra, ``AttributeError`` from an out-of-tree plugin
+                # without ``probe()``) all collapse into one message.
+                # Naming any of them here would import from
+                # ``core.grading.bundle_store`` and break the
+                # orchestration-surface plug-in seam.
+                raise ValueError(
+                    f"grader.snapshot.store (type={grader.snapshot.store.type!r}) "
+                    f"is not reachable at run-start: {exc}. Verify the store "
+                    "config and credentials before re-running; snapshot mode "
+                    "cannot record bundles until the store answers."
+                ) from exc
+        finally:
+            store.close()
 
     def _build_pending_trials(
         self,


### PR DESCRIPTION
## Summary

`BundleStore` Protocol grows a required `probe(self) -> None` method; `LocalDiskBundleStore` writes+deletes a sentinel under `<root_dir>/grade_bundles/`; `S3BundleStore` calls `head_bucket(Bucket=self.bucket)`; `Orchestrator._validate_snapshot_mode_compatibility` invokes it after the existing backend capability probe and wraps every failure into an actionable `ValueError` at run-start. Misconfigured stores now abort the run before any trial produces, replacing the previous silent per-trial `SnapshotStatus.produce_failed` spray from `Conductor._produce_grade_bundle`'s intentional best-effort `except Exception`.

Closes #1457.

## Design choices

| Decision | Rationale |
|---|---|
| Required Protocol method (not optional / `runtime_checkable` hasattr) | By-type contract, not by-convention. Missing `probe()` on an out-of-tree plugin surfaces as an `AttributeError` the orchestrator's `except Exception` collapses into the same actionable `ValueError` (with the `AttributeError` preserved in `__cause__` for plugin authors). By-convention would leave the run-start gate silently un-fired on plugin drift. |
| Unconditional probe (no `snapshot.startup_probe` opt-out flag) | Fail-loud (AGENTS.md Rule 1). Strict-IAM operators with `s3:PutObject` but no `s3:HeadBucket` newly fail at run-start; the documented escape hatch is `S3BundleStore(bucket=..., client=<pre-built boto3 client>)` whose credentials pass `head_bucket`. |
| Orchestrator wire-up uses `except Exception as exc:` with zero new imports | `grimp` (used by importlinter 2.13) counts `TYPE_CHECKING` imports the same as runtime, so importing `BundleStoreError` even under `if TYPE_CHECKING:` would trip the `grader-detach` fence. Structural typing on `store.probe()` + `except Exception` is the only shape that keeps `grader-detach` KEPT with no waiver AND uniformly catches all three failure families (`BundleStoreUnreachableError`, `RuntimeError("bundle-store-s3")` install-hint, `AttributeError` from unupgraded plugins). |
| New `BundleStoreUnreachableError(BundleStoreError)` — annotated as tidy-not-load-bearing | No production path branches on the subclass (orchestrator catches `Exception`); the class exists for test/debug clarity only. Distinct semantics from `BundleNotFoundError` (URI didn't resolve) — this means "store isn't usable at all". |
| `head_bucket` over `list_objects_v2 MaxKeys=1` | Idiomatic minimal AWS probe. Both require `s3:ListBucket`, so no permission-scope difference. |
| S3 `probe()` imports `botocore.exceptions` AFTER `self._boto3_client()` | Applied post-correctness-review: the local `from botocore.exceptions import ...` would raise `ImportError` first when the `bundle-store-s3` extra is entirely uninstalled, hiding the friendly `RuntimeError(_BOTO3_INSTALL_HINT)`. Reordering preserves install-hint parity between `put()` and `probe()`. Test now blocks both `boto3` and `botocore` in `sys.modules` to lock the parity. |
| Test placement: extend `test_bundle_store_{s3,local_disk}.py` unit files (not mint a new canonical) | Applied post-critic-review: the existing files already carry the exact Stubber-driven fixture patterns the probe tests need; Stubber-mocked probes are unit-tier, not byte-locked canonical. Only the `probe-then-put ≡ put` byte-parity property is canonical-shaped — extended into `tests/canonical/test_bundle_store_content_addressability.py`. |

## Scope of change

- **`tolokaforge/core/grading/bundle_store.py`** — Protocol growth, `BundleStoreUnreachableError` subclass, `_S3_CREDENTIAL_HINT` module constant, two `probe()` impls, `S3BundleStore` docstring warning rewritten (dropped `tracked in #1457` mis-attribution, points at newly-filed #1538 for the SecretManager routing that was the docstring's actual scope).
- **`tolokaforge/core/orchestrator.py`** — probe block in `_validate_snapshot_mode_compatibility` under `try / except Exception as exc: raise ValueError(...) from exc; finally: store.close()`. Zero new imports. Docstring now describes "Three guards".
- **`tests/unit/grading/test_bundle_store_{s3,local_disk}.py`** — new `TestS3BundleStoreProbe` + `TestLocalDiskBundleStoreProbe` classes; `test_lazy_boto3_import` extended to lock the install-hint parity between `put()` and `probe()`.
- **`tests/canonical/test_bundle_store_content_addressability.py`** — `test_probe_then_put_byte_identical_to_put_alone` sha256-walk asserts probe leaves zero residue.
- **`tests/unit/core/test_orchestrator_snapshot_startup_validation.py`** — new `TestBundleStoreProbeGate` (5 cases including the unupgraded-plugin `MagicMock(spec=['put','get','close'])` → `ValueError` with `AttributeError` in `__cause__` regression lock).
- **`CHANGELOG.md`** — `### Changed` (Protocol widening + migration one-liner `def probe(self) -> None: return None` + strict-IAM behaviour change + injected-`client=` escape hatch + `AttributeError`-in-`__cause__` diagnostic for unupgraded plugins) and `### Fixed` (run-start visibility over per-trial `produce_failed` spray).
- **`docs/GRADER_SERVICE.md`** — Protocol snippet grows `probe()`; one paragraph on the run-start probe contract and the `__cause__`-preserved unupgraded-plugin diagnostic.
- **`docs/RUNNER.md` + `docs/DETACHED_GRADING.md`** — startup-refusal enumeration extended to name the new bundle-store probe; count-free phrasing (`"Each refusal names…"`) instead of the pre-PR `"Both refusals…"`.

## Test plan

- [x] `uv run --active lint-imports` → 10 kept, 0 broken (`grader-detach` KEPT with zero new imports on `orchestrator.py`).
- [x] Targeted lane (`test_bundle_store_s3.py test_bundle_store_local_disk.py test_bundle_store_content_addressability.py test_orchestrator_snapshot_startup_validation.py`) → 45 passed.
- [x] Adjacent lane (`test_snapshot_bundle_config.py test_produce_grade_bundle_seam.py`) → 65 passed.
- [x] Full canonical `-k bundle` → 129 passed.

## Reviewer coverage

- **reviewer-correctness** → APPROVE WITH NITS: import ordering in `S3BundleStore.probe()` broke install-hint parity when `bundle-store-s3` extra is uninstalled — fixed inline (`_boto3_client()` now runs before the `botocore.exceptions` local import) + `test_lazy_boto3_import` tightened to block both `boto3` and `botocore` in `sys.modules`.
- **reviewer-type-fit** → APPROVE: Protocol/dataclass split correct, error hierarchy correct, `grader-detach` verified green, `MagicMock(spec=['put','get','close'])` correctly excludes `probe`, canonical/unit markers in the right files.
- **reviewer-hygiene** → REQUEST CHANGES: stale doc references in `docs/RUNNER.md` + `docs/DETACHED_GRADING.md` still described the pre-PR two-refusal startup contract — fixed inline in follow-up commit `c253a610` (added the bundle-store probe bullet; dropped `"both"` / `"both preconditions"` hard-count phrasing).

## Follow-ups

- **#1538** — SecretManager routing for `S3BundleStore._boto3_client()` (filed by the architect during planning; the scope originally mis-attributed to #1457 by the class docstring warning).