### PR TITLE
feat(automation): cost summary for the integration run (agents, wire probes, key deltas)

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -248,6 +248,13 @@ jobs:
         # simulator too, so the gateway must serve BOTH models.
         run: |
           set -euo pipefail
+          # Cost accounting: the effective route (the summary reads it - on the gateway route
+          # the probes are billed elsewhere) and the first key snapshot, kept OUTSIDE
+          # observation/ so the key's lifetime usage never lands in an artifact.
+          # docs/AUTO_INTEGRATION.md § Cost summary.
+          mkdir -p observation/cost "$RUNNER_TEMP/cost"
+          printf 'openrouter\n' > observation/cost/route.txt
+          OPENROUTER_API_KEY="$ARENA_KEY" uv run automation key-snapshot --out "$RUNNER_TEMP/cost/key_start.json" || true
           printf '%s\n' "OPENROUTER_API_KEY=$ARENA_KEY" > .env
           if [ "$ROUTE" = "litellm" ]; then
             if [ -n "$PROXY_BASE_URL" ] && [ -n "$PROXY_API_KEY" ]; then
@@ -279,6 +286,7 @@ jobs:
               if [ -n "$PROXY_PREFERRED_ROUTE" ]; then
                 printf '%s\n' "LLM_PROXY_PREFERRED_ROUTE=$PROXY_PREFERRED_ROUTE" >> .env
               fi
+              printf 'litellm\n' > observation/cost/route.txt
               echo "every openrouter/openai call in this run (candidate + user simulator) goes through the LLM gateway"
             else
               echo "::warning title=Gateway route unavailable::route=litellm was requested but ARENA_AUTOMATION_LLM_PROXY_BASE_URL / _API_KEY are not set; probing over OpenRouter instead"
@@ -553,6 +561,9 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.ARENA_AUTOMATION_OPENROUTER_API_KEY }}
         run: |
           set -euo pipefail
+          # Second key snapshot: observe is over, resolve has not started, so the delta against
+          # key_start is the observe stage's billed spend. docs/AUTO_INTEGRATION.md § Cost summary.
+          uv run automation key-snapshot --out "$RUNNER_TEMP/cost/key_after_observe.json" || true
           printf 'model_list:\n  - model_name: %s\n    litellm_params:\n      model: %s\n      api_key: os.environ/OPENROUTER_API_KEY\nlitellm_settings:\n  drop_params: true\n' \
             "$AGENT_MODEL" "$RESOLVE_AGENT_OR_MODEL" > /tmp/litellm.config.yaml
           echo "--- gateway config ---"; cat /tmp/litellm.config.yaml
@@ -642,10 +653,16 @@ jobs:
             # include candidate-model output, and GATEWAY_RUNNER_KEY is a network-admission
             # credential rather than a budget-bounded one. The step needs those values only
             # for `automation reprobe`, not for the agent.
+            # stream-json + tee: the transcript still reaches the job log (one JSON event per
+            # line) and the final `result` event lands in the file with the run's cost + turn
+            # count for `automation cost-summary`. docs/AUTO_INTEGRATION.md § Cost summary.
             env -u LLM_PROXY_SUNDAY_ORDER_ID -u LLM_PROXY_GATEWAY_RUNNER_KEY \
               claude -p "$(cat /tmp/compose_$i.md)" --model "$AGENT_MODEL" \
               --allowedTools "Bash,Read,Edit,Write" --dangerously-skip-permissions \
-              --max-turns "${RESOLVE_MAX_TURNS}" --verbose || true
+              --max-turns "${RESOLVE_MAX_TURNS}" --verbose --output-format stream-json \
+              | tee "observation/resolve/agent_iter_$i.jsonl" || true
+            uv run automation agent-digest "observation/resolve/agent_iter_$i.jsonl" \
+              --out "observation/cost/agent_iter_$i.json" || true
             # Agent-requested escalation: if it lacks the data to produce a CORRECT policy (a
             # data-bound quirk whose scope needs real-domain evidence the observe never surfaced),
             # it sets `needs_human: true` in decision.json. Break immediately - no wasted
@@ -725,10 +742,14 @@ jobs:
           fill "$P/resolve_finalize.md" > /tmp/finalize.md
           # `|| true`: if the agent hits --max-turns it exits non-zero; do not abort - the commit
           # step below decides success by whether files changed.
+          # Same capture as the resolve loop: transcript to the log, result event to the file.
           env -u LLM_PROXY_SUNDAY_ORDER_ID -u LLM_PROXY_GATEWAY_RUNNER_KEY \
             claude -p "$(cat /tmp/finalize.md)" --model "$AGENT_MODEL" \
             --allowedTools "Bash,Read,Edit,Write" --dangerously-skip-permissions \
-            --max-turns "${RESOLVE_MAX_TURNS}" --verbose || true
+            --max-turns "${RESOLVE_MAX_TURNS}" --verbose --output-format stream-json \
+            | tee observation/resolve/agent_finalize.jsonl || true
+          uv run automation agent-digest observation/resolve/agent_finalize.jsonl \
+            --out observation/cost/agent_finalize.json || true
 
       - name: Finalize - verify + commit + report (holds GH_TOKEN; no agent)
         id: finalize
@@ -1015,3 +1036,58 @@ jobs:
             --channel "$SLACK_CHANNEL" --pr "$PR" --model "$CANDIDATE_NAME" --mention \
             --icon pipeline_error --text 'Pipeline error: unexpected failure, PR left mid-state' \
             --pr-url "$PR_URL" --run-url "$RUN_URL" || true
+
+      - name: Cost summary (agents + probes + key usage)
+        # The accounting tail, whatever the outcome once the model is known: what this run
+        # spent, attributed per stage. Agent cost is the Claude Code CLI's own report (Anthropic
+        # list price; cache writes are not surfaced on the gateway route, so a lower bound), wire
+        # cost comes from the run aggregates, and the key snapshots give the billed delta on
+        # ARENA_AUTOMATION_OPENROUTER_API_KEY - the only figure that covers the capability
+        # probes, and one that includes any concurrent run on the same key (on the litellm
+        # route the probes bill the gateway key instead; the summary reads cost/route.txt and
+        # says so). Informational and unable to fail the job: no mention, every call `|| true`,
+        # continue-on-error. A run with nothing spent on record writes no md/txt, so nothing is
+        # posted. The key reaches `uv run automation` here under the same accepted-risk envelope
+        # as the post-agent `automation reprobe` calls above. docs/AUTO_INTEGRATION.md § Cost summary.
+        if: always() && steps.parse.outcome == 'success'
+        continue-on-error: true
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.ARENA_AUTOMATION_OPENROUTER_API_KEY }}
+          CANDIDATE_NAME: ${{ steps.parse.outputs.name }}
+        run: |
+          mkdir -p observation/cost "$RUNNER_TEMP/cost"
+          uv run automation key-snapshot --out "$RUNNER_TEMP/cost/key_end.json" || true
+          uv run automation cost-summary observation \
+            --key-dir "$RUNNER_TEMP/cost" \
+            --out observation/cost/cost_summary.json \
+            --md-out observation/cost/cost_summary.md \
+            --line-out observation/cost/cost_summary.txt \
+            --run-url "$RUN_URL" || true
+          if [ -s observation/cost/cost_summary.md ]; then
+            gh pr comment "$PR" -R "$REPO" --body-file observation/cost/cost_summary.md || true
+          fi
+          if [ -s observation/cost/cost_summary.txt ]; then
+            uv run automation slack reply \
+              --channel "$SLACK_CHANNEL" --pr "$PR" --model "$CANDIDATE_NAME" \
+              --icon cost_summary --text "$(cat observation/cost/cost_summary.txt)" \
+              --run-url "$RUN_URL" || true
+          fi
+
+      - name: Upload cost bundle (summary + normalized agent result events)
+        # ONLY the summary and the normalized result events (cost, turns, usage, ending). Never
+        # the raw agent transcripts: a `Bash(env)` or `cat .env` tool result in there would
+        # carry the run's keys, and GitHub masks the job log, not an artifact of a public repo.
+        # Never the key snapshots either: they hold the key's lifetime usage (they live in
+        # RUNNER_TEMP; only the deltas are in the summary).
+        if: always() && steps.parse.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-cost-pr${{ github.event.pull_request.number || inputs.pr }}
+          path: |
+            observation/cost/cost_summary.json
+            observation/cost/cost_summary.md
+            observation/cost/cost_summary.txt
+            observation/cost/agent_*.json
+          if-no-files-found: ignore
+          retention-days: 30

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -361,6 +361,39 @@ The fork-reject path is PR-comment-only (a fork `pull_request` run gets no secre
 notifier cannot post). `SLACK_MENTIONS` pings fire on the terminal and error notifications so a
 human is alerted when the PR needs review or the run broke.
 
+## Cost summary
+
+Every run ends with an accounting tail once the candidate is known, whatever the outcome:
+`automation cost-summary` writes `observation/cost/cost_summary.{json,md,txt}`, posts the markdown
+as a PR comment, sends the one-liner to the Slack thread (`cost_summary` icon role, no mention) and
+uploads the `integration-cost-pr<N>` artifact. Three sources, kept apart because they measure
+different things:
+
+| Source | Covers | What the number is |
+|---|---|---|
+| the `claude -p` result event (`total_cost_usd`, `usage`, `num_turns`) of every resolve iteration and the finalize run - the agent calls run with `--output-format stream-json`, tee'd to `observation/resolve/agent_*.jsonl` so the transcript still reaches the job log | the agent | the CLI's own report at Anthropic list price; cache WRITES are not surfaced on the gateway route, so a lower bound |
+| `wire_probes_*/aggregate.json` (observe) and `resolve/reprobe_*/` (reprobe) | the candidate's wire calls only - the capability + variant probes and the user simulator leave no cost artifact | exact for what it covers |
+| `automation key-snapshot` at run start (`.env` step), after observe (gateway step - so only when the gate chains to resolve; on an observe -> needs-human run the whole delta is the observe spend and the summary says so) and at the end -> `$RUNNER_TEMP/cost/key_*.json`, i.e. OpenRouter `GET /api/v1/key` | everything billed on `ARENA_AUTOMATION_OPENROUTER_API_KEY`, including the probes without an artifact | the billed figure; key-level, so a concurrent run on the same key is included |
+
+**Route caveat.** The `.env` step records the route it actually configured in
+`observation/cost/route.txt`. On `litellm` the observe + reprobe probes (candidate and user
+simulator) bill the gateway key, so the key deltas cover the agent alone; the summary labels the
+observe delta "billed on the gateway key" and says so in its notes.
+
+**What leaves the runner.** The artifact holds the summary and the NORMALIZED agent result events
+(`observation/cost/agent_*.json`: cost, turns, usage, how the run ended) - never the raw
+`agent_*.jsonl` transcripts, whose tool results can echo the agent's environment (`env`, `.env`),
+and GitHub masks the job log, not a public repo's artifact. The key snapshots hold the key's
+lifetime usage figure, so they stay in `RUNNER_TEMP` and only their deltas reach the summary.
+
+The summary names the source of every number and lists the caveats. A missing snapshot degrades
+to the attributed lower bound (agents + wire) rather than failing anything; a run with nothing spent
+on record writes the JSON but no md/txt, so nothing is posted. Accounting can never fail the
+integration: every call is `|| true`, both steps are `continue-on-error`, and `key-snapshot` exits
+0 on any miss. `automation agent-digest <file> --out <json>` prints one line per agent run
+(subtype, turns, cost) into the job log - where the old `--verbose` text transcript used to say how
+a run ended - and writes the normalized event the artifact uploads.
+
 ## Prompts (`tools/automation/src/automation/prompts/`)
 
 The analysis-dimension briefs interpret an eval or observe artifact (one dimension per
@@ -407,6 +440,9 @@ sub-agent); the resolve prompts drive the fix loop. `index.yaml` is the machine-
   resolves free-text model phrases to OpenRouter slugs (deterministic, version-strict), and
   `slack-poll` scans the channel (last `--window-hours`), replies per request, and emits the
   integration plan that `slack-integrate.yml` turns into a draft PR + `workflow_dispatch`.
+- `automation cost-summary` / `key-snapshot` / `agent-digest` - the accounting tail (see "Cost
+  summary" above): key-usage snapshots, the per-run cost summary (JSON + markdown + one-liner) and
+  the one-line job-log digest of an agent run's result event.
 - `tests/unit/llm/test_policy_no_regression.py` - GENERIC (model-agnostic) anti-over-reach
   gate: every model's resolved response policy must keep an already-valid tool-call arg valid.
 - `tests/unit/llm/test_policy_array_recovery.py` - schema-driven recovery oracle: inject

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -14,6 +14,7 @@ import typer
 from automation import (
     bucket_classifier,
     cert,
+    cost_summary,
     gateway_catalog,
     greencheck,
     model_resolver,
@@ -147,6 +148,56 @@ def observe_findings(
 ) -> None:
     """Emit deterministic observe-stage findings.json (raw stats) from an obs dir."""
     raise typer.Exit(observe.run(obs_dir, out=out, summary_out=summary_out, run_url=run_url))
+
+
+@app.command("cost-summary")
+def cost_summary_cmd(
+    obs_dir: str = typer.Argument(..., help="the observation artifact directory"),
+    out: str = typer.Option(..., "--out", help="cost summary JSON output path"),
+    md_out: str | None = typer.Option(
+        None, "--md-out", help="optional markdown output path (the PR comment body)"
+    ),
+    line_out: str | None = typer.Option(
+        None, "--line-out", help="optional one-line output path (the Slack text)"
+    ),
+    run_url: str | None = typer.Option(None, "--run-url", help="workflow run URL to link"),
+    key_dir: str | None = typer.Option(
+        None,
+        "--key-dir",
+        help="directory holding the key_*.json snapshots (default: <obs_dir>/cost); the "
+        "workflow keeps them outside the observation dir so they never reach an artifact",
+    ),
+) -> None:
+    """Attribute the run's spend: agent self-reports, wire aggregates, key-usage deltas."""
+    raise typer.Exit(
+        cost_summary.run(
+            obs_dir, out=out, md_out=md_out, line_out=line_out, run_url=run_url, key_dir=key_dir
+        )
+    )
+
+
+@app.command("key-snapshot")
+def key_snapshot_cmd(
+    out: str = typer.Option(..., "--out", help="where to write the key usage snapshot JSON"),
+) -> None:
+    """Snapshot the automation key's usage (OpenRouter GET /api/v1/key). Best-effort, exit 0."""
+    raise typer.Exit(cost_summary.run_key_snapshot(out))
+
+
+@app.command("agent-digest")
+def agent_digest_cmd(
+    path: str = typer.Argument(
+        ..., help="a claude -p output file (json / json array / stream-json)"
+    ),
+    out: str | None = typer.Option(
+        None,
+        "--out",
+        help="also write the NORMALIZED result event (cost, turns, usage, ending - no "
+        "transcript) here; this is the shape the cost artifact uploads",
+    ),
+) -> None:
+    """Print one line (subtype, turns, cost) for an agent run, for the job log."""
+    raise typer.Exit(cost_summary.run_digest(path, out=out))
 
 
 def _classify_paths_format(cls: bucket_classifier.Classification, fmt: str) -> str:

--- a/tools/automation/src/automation/cost_summary.py
+++ b/tools/automation/src/automation/cost_summary.py
@@ -63,7 +63,7 @@ def _usd(value: float | None, *, escape: bool = False) -> str:
     if value is None:
         return "n/a"
     # GitHub renders `$...$` on one line as math; the markdown body escapes its dollars.
-    return ("\\$" if escape else "$") + f"{value:,.4f}"
+    return ("\\$" if escape else "$") + f"{value:,.2f}"
 
 
 def _num(value: Any, default: float = 0.0) -> float:

--- a/tools/automation/src/automation/cost_summary.py
+++ b/tools/automation/src/automation/cost_summary.py
@@ -1,0 +1,568 @@
+"""Cost accounting for one auto-integration run (``automation cost-summary``).
+
+Three sources, three different truths, kept apart on purpose:
+
+* **agents** - the resolve / finalize ``claude -p`` runs report their own spend
+  (``total_cost_usd`` in the CLI's ``result`` event). That is the Anthropic list price for the
+  alias; on the gateway route cache WRITES are not surfaced, so it is a lower bound.
+* **wire probes** - the engine's own ``aggregate.json`` under every ``wire_probes_*`` run
+  (observe) and ``resolve/reprobe_*`` (reprobe). Exact for the candidate's wire calls; the
+  capability + variant probes and the user simulator leave no cost artifact at all.
+* **key usage** - snapshots of the automation key's lifetime usage (OpenRouter
+  ``GET /api/v1/key``) at run start, after observe and at the end. Their deltas are the BILLED
+  figure and the only one that also covers the probes without an artifact. Key-level, so a
+  concurrent run on the same key is included; on the ``litellm`` route the probes bill the
+  gateway key instead, and the deltas cover the agent alone. The summary says both.
+
+What may leave the runner: the summary and the NORMALIZED agent result events (cost, turns,
+usage, how the run ended - never the transcript, which can echo the agent's environment). The
+key snapshots carry the key's lifetime usage figure, so the workflow keeps them outside the
+observation dir and only their deltas reach the summary.
+
+See docs/AUTO_INTEGRATION.md § Cost summary.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import glob
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from tolokaforge.secrets import EnvProvider, SecretManager
+
+KEY_USAGE_URL = "https://openrouter.ai/api/v1/key"
+
+#: Under the observation dir: the effective route marker, the normalized agent result events
+#: and the rendered summary - everything in here is safe to upload.
+COST_DIR = "cost"
+ROUTE_FILE = "route.txt"
+DEFAULT_ROUTE = "openrouter"
+GATEWAY_ROUTE = "litellm"
+KEY_SNAPSHOTS = ("key_start", "key_after_observe", "key_end")
+
+_USAGE_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+)
+_ITER_RE = re.compile(r"^agent_iter_(\d+)\.")
+
+
+def _log(message: str) -> None:
+    print(f"cost-summary: {message}", file=sys.stderr)
+
+
+def _usd(value: float | None, *, escape: bool = False) -> str:
+    if value is None:
+        return "n/a"
+    # GitHub renders `$...$` on one line as math; the markdown body escapes its dollars.
+    return ("\\$" if escape else "$") + f"{value:,.4f}"
+
+
+def _num(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Agent results (claude -p output)
+# ---------------------------------------------------------------------------
+
+
+def parse_agent_result(text: str) -> dict[str, Any] | None:
+    """The ``result`` event of a ``claude -p`` run, whatever output format produced *text*.
+
+    ``--output-format json`` prints one object; with ``--verbose`` it prints an array of every
+    message; ``stream-json`` prints one JSON object per line. All three end in a
+    ``{"type": "result", ...}`` object, which is the one carrying the totals. ``None`` when no
+    such object is found (an agent that never got to answer, or a file that is not JSON).
+    """
+    if not text or not text.strip():
+        return None
+    try:
+        parsed = json.loads(text)
+    except ValueError:
+        parsed = None
+    if isinstance(parsed, dict):
+        return parsed if parsed.get("type") == "result" else None
+    if isinstance(parsed, list):
+        results = [
+            item for item in parsed if isinstance(item, dict) and item.get("type") == "result"
+        ]
+        return results[-1] if results else None
+    # JSON lines: keep the last result event, ignore anything that does not parse.
+    last: dict[str, Any] | None = None
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            item = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(item, dict) and item.get("type") == "result":
+            last = item
+    return last
+
+
+def iteration_number(path: Path) -> int | None:
+    """The resolve iteration a result file belongs to, from its name (``agent_iter_<n>.*``)."""
+    match = _ITER_RE.match(path.name)
+    return int(match.group(1)) if match else None
+
+
+def normalize_agent_result(
+    result: dict[str, Any] | None, *, file: str, iteration: int | None = None
+) -> dict[str, Any]:
+    """The subset of a result event the summary keeps - cost, turns, usage, how the run ended.
+
+    Deliberately NOT the ``result`` text or anything else from the transcript: this is the
+    shape that gets uploaded.
+    """
+    usage_raw = result.get("usage") if isinstance(result, dict) else None
+    usage = usage_raw if isinstance(usage_raw, dict) else {}
+    return {
+        "file": file,
+        "iteration": iteration,
+        "parsed": result is not None,
+        "total_cost_usd": round(_num(result.get("total_cost_usd")), 6) if result else None,
+        "num_turns": int(_num(result.get("num_turns"))) if result else None,
+        "duration_ms": int(_num(result.get("duration_ms"))) if result else None,
+        "subtype": str(result.get("subtype") or "") if result else None,
+        "is_error": bool(result.get("is_error")) if result else None,
+        "usage": {field: int(_num(usage.get(field))) for field in _USAGE_FIELDS},
+    }
+
+
+def _is_normalized(data: Any) -> bool:
+    return isinstance(data, dict) and {"file", "parsed", "usage"} <= set(data)
+
+
+def read_agent_result(path: Path) -> dict[str, Any]:
+    """A raw ``claude -p`` output file OR an already-normalized one (the uploaded shape)."""
+    try:
+        text = path.read_text()
+    except OSError:
+        text = ""
+    try:
+        data = json.loads(text) if text.strip() else None
+    except ValueError:
+        data = None
+    if _is_normalized(data):
+        return data
+    return normalize_agent_result(
+        parse_agent_result(text), file=path.name, iteration=iteration_number(path)
+    )
+
+
+def _agent_files(obs_dir: Path) -> tuple[list[Path], Path | None]:
+    # The raw files live under resolve/ on the runner; the normalized copies under cost/ are
+    # what an artifact holds, so a summary rebuilt from a download still finds the agents.
+    for directory in (obs_dir / "resolve", obs_dir / COST_DIR):
+        iterations = sorted(
+            (
+                p
+                for p in directory.glob("agent_iter_*.json*")
+                if p.is_file() and iteration_number(p) is not None
+            ),
+            key=lambda p: iteration_number(p) or 0,
+        )
+        finalize = next((p for p in directory.glob("agent_finalize.json*") if p.is_file()), None)
+        if iterations or finalize:
+            return iterations, finalize
+    return [], None
+
+
+def agent_costs(obs_dir: Path) -> dict[str, Any]:
+    iterations, finalize = _agent_files(obs_dir)
+    iteration_results = [read_agent_result(p) for p in iterations]
+    finalize_result = read_agent_result(finalize) if finalize else None
+    all_results = iteration_results + ([finalize_result] if finalize_result else [])
+    parsed = [r for r in all_results if r["parsed"]]
+    return {
+        "iterations": iteration_results,
+        "finalize": finalize_result,
+        "runs": len(all_results),
+        "runs_parsed": len(parsed),
+        "total_cost_usd": round(sum(_num(r["total_cost_usd"]) for r in parsed), 6),
+        "total_turns": sum(int(r["num_turns"] or 0) for r in parsed),
+        "usage": {field: sum(int(r["usage"][field]) for r in parsed) for field in _USAGE_FIELDS},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Wire probes (engine aggregate.json)
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_costs(paths: list[str]) -> dict[str, Any]:
+    total = 0.0
+    tokens = {"prompt": 0, "completion": 0, "cached": 0}
+    runs = 0
+    unpriced = 0
+    for path in paths:
+        try:
+            data = json.loads(Path(path).read_text())
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        runs += 1
+        # An engine with no pricing for the model writes null, not 0: unknown, and said so.
+        if data.get("total_cost_usd") is None:
+            unpriced += 1
+        total += _num(data.get("total_cost_usd"))
+        tokens["prompt"] += int(_num(data.get("total_prompt_tokens")))
+        tokens["completion"] += int(_num(data.get("total_completion_tokens")))
+        tokens["cached"] += int(_num(data.get("total_cached_tokens")))
+    return {
+        "runs": runs,
+        "unpriced_runs": unpriced,
+        "total_cost_usd": round(total, 6),
+        "tokens": tokens,
+    }
+
+
+def wire_costs(obs_dir: Path) -> dict[str, Any]:
+    # Same discovery as observe._wire_findings: the observe stage writes one wire_probes_* run
+    # directly under the obs dir, a reprobe writes its own under resolve/reprobe_<i>/.
+    observe = _aggregate_costs(sorted(glob.glob(str(obs_dir / "wire_probes_*" / "aggregate.json"))))
+    reprobe = _aggregate_costs(
+        sorted(
+            glob.glob(str(obs_dir / "resolve" / "reprobe_*" / "wire_probes_*" / "aggregate.json"))
+        )
+    )
+    return {
+        "observe": observe,
+        "reprobe": reprobe,
+        "unpriced_runs": observe["unpriced_runs"] + reprobe["unpriced_runs"],
+        "total_cost_usd": round(observe["total_cost_usd"] + reprobe["total_cost_usd"], 6),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Route marker + key usage snapshots (OpenRouter GET /api/v1/key)
+# ---------------------------------------------------------------------------
+
+
+def read_route(obs_dir: Path) -> str:
+    """The route the workflow's .env step actually configured (``openrouter`` when unrecorded)."""
+    try:
+        route = (obs_dir / COST_DIR / ROUTE_FILE).read_text().strip().lower()
+    except OSError:
+        return DEFAULT_ROUTE
+    return route or DEFAULT_ROUTE
+
+
+def snapshot_key(out: Path, *, api_key: str | None = None, timeout: float = 20.0) -> bool:
+    """Write the key's lifetime usage to *out* - the one number a delta needs. False on any miss.
+
+    The figure is account-key-level, and it is the key's LIFETIME spend, which is why the
+    workflow keeps these files out of every artifact.
+    """
+    if api_key is None:
+        # Env-only, like gateway_catalog: the workflow maps the secret in per step, and dotenv
+        # precedence would let a developer's local .env answer a CI run.
+        api_key = SecretManager([EnvProvider()]).get_secret("OPENROUTER_API_KEY")
+    if not api_key:
+        _log("no OPENROUTER_API_KEY in the environment; skipping the key snapshot")
+        return False
+    request = urllib.request.Request(KEY_USAGE_URL, headers={"Authorization": f"Bearer {api_key}"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            body = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        _log(f"key snapshot failed: {exc}")
+        return False
+    data = body.get("data") if isinstance(body, dict) else None
+    if not isinstance(data, dict) or data.get("usage") is None:
+        _log("key snapshot: unexpected payload (no data.usage)")
+        return False
+    snapshot = {
+        "at": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+        "usage_usd": _num(data.get("usage")),
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(snapshot, indent=2) + "\n")
+    return True
+
+
+def read_key_snapshot(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) and "usage_usd" in data else None
+
+
+def key_usage(key_dir: Path) -> dict[str, Any]:
+    """Deltas between the snapshots in *key_dir*; the absolute figures stay on the runner."""
+    snaps = {name: read_key_snapshot(key_dir / f"{name}.json") for name in KEY_SNAPSHOTS}
+
+    def delta(a: str, b: str) -> float | None:
+        if snaps[a] is None or snaps[b] is None:
+            return None
+        return round(_num(snaps[b]["usage_usd"]) - _num(snaps[a]["usage_usd"]), 6)
+
+    return {
+        "snapshots": {
+            name: ({"at": snap.get("at")} if snap is not None else None)
+            for name, snap in snaps.items()
+        },
+        "deltas_usd": {
+            "observe": delta("key_start", "key_after_observe"),
+            "resolve_finalize": delta("key_after_observe", "key_end"),
+            "total": delta("key_start", "key_end"),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+
+def build_summary(
+    obs_dir: Path, *, run_url: str | None = None, key_dir: Path | None = None
+) -> dict[str, Any]:
+    manifest_path = obs_dir / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
+    except (OSError, ValueError):
+        manifest = {}
+    if not isinstance(manifest, dict):
+        manifest = {}
+    route = read_route(obs_dir)
+    agents = agent_costs(obs_dir)
+    wire = wire_costs(obs_dir)
+    usage = key_usage(key_dir if key_dir is not None else obs_dir / COST_DIR)
+    attributed = round(agents["total_cost_usd"] + wire["total_cost_usd"], 6)
+    deltas = usage["deltas_usd"]
+    measured = deltas["total"]
+    # The after-observe snapshot is taken by the gateway step, which runs only when the gate
+    # chains to resolve. On an observe -> needs-human run it is missing while start + end are
+    # there, and no agent ran: the whole delta IS the observe spend, so say so instead of n/a.
+    observe_is_total = deltas["observe"] is None and measured is not None and agents["runs"] == 0
+    if observe_is_total:
+        deltas["observe"] = measured
+
+    notes = [
+        "agent cost is the Claude Code CLI's own report at Anthropic list price; cache writes "
+        "are not surfaced on the gateway route, so it is a lower bound",
+        "the aggregates cover the candidate's wire calls only; the capability + variant probes "
+        "and the user simulator's calls leave no cost artifact, so the attributed total is a "
+        "lower bound of the run's spend",
+        "key deltas are account-key-level (ARENA_AUTOMATION_OPENROUTER_API_KEY) and include "
+        "any run that shared the key in the same window",
+    ]
+    if route == GATEWAY_ROUTE:
+        notes.append(
+            "route=litellm: the observe + reprobe probes (candidate and user simulator) were "
+            "billed on the gateway key, not on this one, so the key deltas cover the agent alone "
+            "and the observe delta is not a probe cost"
+        )
+    if measured is None:
+        notes.append("key usage deltas unavailable (a snapshot is missing)")
+    if observe_is_total:
+        notes.append(
+            "resolve did not run (the after-observe snapshot exists only when the gate chains), "
+            "so the whole key delta is the observe spend"
+        )
+    if wire["unpriced_runs"]:
+        notes.append(
+            f"{wire['unpriced_runs']} wire run(s) carry no cost (the engine had no pricing for "
+            "the model); they count as zero here"
+        )
+    if agents["runs"] and agents["runs_parsed"] < agents["runs"]:
+        notes.append(
+            f"{agents['runs'] - agents['runs_parsed']} agent run(s) produced no parseable result "
+            "event and count as zero here"
+        )
+
+    return {
+        "schema_version": 1,
+        "candidate": manifest.get("candidate"),
+        "pr": manifest.get("pr"),
+        "run_url": run_url,
+        "route": route,
+        "agents": agents,
+        "wire_probes": wire,
+        "key_usage": usage,
+        "totals_usd": {
+            "attributed": attributed,
+            "agents": agents["total_cost_usd"],
+            "wire_probes": wire["total_cost_usd"],
+            "measured_key_delta": measured,
+        },
+        # A run with nothing on record (parse failed early, or every source is missing) has
+        # nothing worth a PR comment or a Slack line; the JSON still records that. A run that
+        # demonstrably ran agents or probes is reported even when every figure came back empty.
+        "noteworthy": (
+            attributed > 0 or bool(measured) or agents["runs"] > 0 or wire["observe"]["runs"] > 0
+        ),
+        "notes": notes,
+    }
+
+
+def render_line(summary: dict[str, Any], *, escape: bool = False) -> str:
+    """One line for Slack: the billed figure first when it exists, the attributed one otherwise."""
+    totals = summary["totals_usd"]
+    agents = summary["agents"]
+    measured = totals["measured_key_delta"]
+
+    def usd(value: float | None) -> str:
+        return _usd(value, escape=escape)
+
+    if measured is None:
+        headline = f"Cost: >= {usd(totals['attributed'])} attributed (key delta unavailable)"
+    elif summary.get("route") == GATEWAY_ROUTE:
+        headline = (
+            f"Cost: {usd(measured)} billed on the automation key (agent only; probes billed the "
+            "gateway key)"
+        )
+    else:
+        headline = f"Cost: {usd(measured)} billed on the automation key"
+    return (
+        f"{headline} - agents {usd(totals['agents'])} over {agents['total_turns']} turns in "
+        f"{agents['runs']} run(s), wire probes {usd(totals['wire_probes'])}"
+    )
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    totals = summary["totals_usd"]
+    agents = summary["agents"]
+    wire = summary["wire_probes"]
+    deltas = summary["key_usage"]["deltas_usd"]
+    gateway = summary.get("route") == GATEWAY_ROUTE
+    candidate = summary.get("candidate") or {}
+    name = candidate.get("name") if isinstance(candidate, dict) else None
+
+    def usd(value: float | None) -> str:
+        return _usd(value, escape=True)
+
+    def agent_row(label: str, item: dict[str, Any]) -> str:
+        turns = item["num_turns"] if item["parsed"] else "?"
+        return (
+            f"| {label} ({turns} turns, {item['subtype'] or 'unparsed'}) | CLI self-report | "
+            f"{usd(item['total_cost_usd'])} |"
+        )
+
+    lines = [
+        "### Cost summary" + (f" - `{name}`" if name else ""),
+        "",
+        render_line(summary, escape=True),
+        "",
+        "| Stage | Source | Cost |",
+        "|---|---|---|",
+        f"| Observe: wire probes ({wire['observe']['runs']} run) | aggregate.json | "
+        f"{usd(wire['observe']['total_cost_usd'])} |",
+        "| Observe: all probes incl. capability + variants | key delta | "
+        + ("n/a (billed on the gateway key)" if gateway else usd(deltas["observe"]))
+        + " |",
+    ]
+    for item in agents["iterations"]:
+        label = f"Resolve agent iter {item['iteration'] if item['iteration'] is not None else '?'}"
+        lines.append(agent_row(label, item))
+    if wire["reprobe"]["runs"]:
+        lines.append(
+            f"| Resolve: reprobe wire ({wire['reprobe']['runs']} run) | aggregate.json | "
+            f"{usd(wire['reprobe']['total_cost_usd'])} |"
+        )
+    if agents["finalize"]:
+        lines.append(agent_row("Finalize agent", agents["finalize"]))
+    lines += [
+        f"| Resolve + finalize, everything on this key | key delta | "
+        f"{usd(deltas['resolve_finalize'])} |",
+        f"| **Total attributed** (agents + wire) | | **{usd(totals['attributed'])}** |",
+        f"| **Total billed** (key delta) | | **{usd(totals['measured_key_delta'])}** |",
+        "",
+    ]
+    usage = agents["usage"]
+    lines.append(
+        f"Agent tokens: {usage['input_tokens']:,} in / {usage['output_tokens']:,} out, "
+        f"cache read {usage['cache_read_input_tokens']:,}, "
+        f"cache write {usage['cache_creation_input_tokens']:,}."
+    )
+    lines += ["", *(f"- {note}" for note in summary["notes"])]
+    if summary.get("run_url"):
+        lines += ["", f"[Run]({summary['run_url']})"]
+    return "\n".join(lines) + "\n"
+
+
+def digest_line(result: dict[str, Any] | None, *, label: str) -> str:
+    """One log line per agent run, so the job log still says how a run ended and what it cost."""
+    if result is None:
+        return f"{label}: no result event (agent produced no parseable output)"
+    return (
+        f"{label}: subtype={result.get('subtype') or '?'} is_error={bool(result.get('is_error'))} "
+        f"turns={int(_num(result.get('num_turns')))} "
+        f"duration={int(_num(result.get('duration_ms'))) // 1000}s "
+        f"cost={_usd(_num(result.get('total_cost_usd')))}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points
+# ---------------------------------------------------------------------------
+
+
+def run(
+    obs_dir: str,
+    *,
+    out: str,
+    md_out: str | None = None,
+    line_out: str | None = None,
+    run_url: str | None = None,
+    key_dir: str | None = None,
+) -> int:
+    summary = build_summary(
+        Path(obs_dir), run_url=run_url, key_dir=Path(key_dir) if key_dir else None
+    )
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(summary, indent=2) + "\n")
+    if not summary["noteworthy"]:
+        # The workflow posts whatever md/line file exists, so not writing them IS the skip.
+        print("cost-summary: nothing spent on record; no PR comment / Slack line written")
+        return 0
+    line = render_line(summary)
+    if md_out:
+        Path(md_out).write_text(render_markdown(summary))
+    if line_out:
+        Path(line_out).write_text(line + "\n")
+    print(line)
+    return 0
+
+
+def run_key_snapshot(out: str) -> int:
+    # Never a failing exit: accounting must not be able to fail the integration.
+    snapshot_key(Path(out))
+    return 0
+
+
+def run_digest(path: str, *, out: str | None = None) -> int:
+    file = Path(path)
+    try:
+        text = file.read_text()
+    except OSError:
+        text = ""
+    result = parse_agent_result(text)
+    print(digest_line(result, label=file.name))
+    if out:
+        # The uploadable shape: cost, turns, usage, ending - no transcript.
+        normalized = normalize_agent_result(
+            result, file=file.name, iteration=iteration_number(file)
+        )
+        out_path = Path(out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(normalized, indent=2) + "\n")
+    return 0

--- a/tools/automation/src/automation/icons.py
+++ b/tools/automation/src/automation/icons.py
@@ -65,6 +65,8 @@ DEFAULT_ICONS: dict[str, str] = {
     "request_unresolved": ":x:",
     # A `via <route>` directive that could not be honoured.
     "route_downgraded": ":warning:",
+    # The accounting tail: what the run spent (docs/AUTO_INTEGRATION.md § Cost summary).
+    "cost_summary": ":moneybag:",
 }
 
 # Slack emoji names are lowercase letters, digits, and - _ +. Anything else

--- a/tools/automation/tests/test_cost_summary.py
+++ b/tools/automation/tests/test_cost_summary.py
@@ -170,7 +170,7 @@ class TestBuildSummary:
             "total": 7.0,
         }
         assert any("resolve did not run" in note for note in summary["notes"])
-        assert "| key delta | \\$7.0000 |" in cs.render_markdown(summary)
+        assert "| key delta | \\$7.00 |" in cs.render_markdown(summary)
 
     def test_unpriced_wire_runs_are_counted_and_said(self, tmp_path):
         obs = tmp_path / "observation"
@@ -210,21 +210,21 @@ class TestBuildSummary:
 class TestRendering:
     def test_the_line_leads_with_the_billed_figure_when_known(self, tmp_path):
         line = cs.render_line(cs.build_summary(_obs_dir(tmp_path)))
-        assert line.startswith("Cost: $6.5000 billed on the automation key - agents $2.0000")
-        assert "over 14 turns in 3 run(s), wire probes $2.5000" in line
+        assert line.startswith("Cost: $6.50 billed on the automation key - agents $2.00")
+        assert "over 14 turns in 3 run(s), wire probes $2.50" in line
         assert "\n" not in line
 
     def test_the_line_falls_back_to_the_attributed_lower_bound(self, tmp_path):
         line = cs.render_line(cs.build_summary(_obs_dir(tmp_path, snapshots=False)))
-        assert line.startswith("Cost: >= $4.5000 attributed (key delta unavailable)")
+        assert line.startswith("Cost: >= $4.50 attributed (key delta unavailable)")
 
     def test_the_markdown_has_one_row_per_stage_escapes_dollars_and_lists_the_notes(self, tmp_path):
         md = cs.render_markdown(cs.build_summary(_obs_dir(tmp_path), run_url="https://run"))
         assert md.startswith("### Cost summary - `x/model`")
-        assert "| Resolve agent iter 1 (7 turns, success) | CLI self-report | \\$1.2500 |" in md
+        assert "| Resolve agent iter 1 (7 turns, success) | CLI self-report | \\$1.25 |" in md
         assert "| Resolve agent iter 2 (? turns, unparsed) | CLI self-report | n/a |" in md
-        assert "| Finalize agent (7 turns, success) | CLI self-report | \\$0.7500 |" in md
-        assert "| **Total billed** (key delta) | | **\\$6.5000** |" in md
+        assert "| Finalize agent (7 turns, success) | CLI self-report | \\$0.75 |" in md
+        assert "| **Total billed** (key delta) | | **\\$6.50** |" in md
         assert "cache read 180,000" in md
         assert "candidate's wire calls only" in md
         assert "[Run](https://run)" in md
@@ -234,7 +234,7 @@ class TestRendering:
     def test_the_digest_line_names_how_the_run_ended(self):
         assert cs.digest_line(None, label="a.jsonl").startswith("a.jsonl: no result event")
         line = cs.digest_line({**_RESULT, "subtype": "error_max_turns"}, label="b.jsonl")
-        assert "subtype=error_max_turns" in line and "turns=7" in line and "cost=$1.2500" in line
+        assert "subtype=error_max_turns" in line and "turns=7" in line and "cost=$1.25" in line
 
 
 class TestKeySnapshot:
@@ -306,8 +306,8 @@ def test_run_writes_json_markdown_and_line(tmp_path, capsys):
     assert code == 0
     assert json.loads((obs / "cost" / "cost_summary.json").read_text())["schema_version"] == 1
     assert (obs / "cost" / "cost_summary.md").read_text().startswith("### Cost summary")
-    assert (obs / "cost" / "cost_summary.txt").read_text().startswith("Cost: $6.5000")
-    assert capsys.readouterr().out.startswith("Cost: $6.5000")
+    assert (obs / "cost" / "cost_summary.txt").read_text().startswith("Cost: $6.50")
+    assert capsys.readouterr().out.startswith("Cost: $6.50")
 
 
 def test_run_writes_only_the_json_when_nothing_was_spent(tmp_path, capsys):

--- a/tools/automation/tests/test_cost_summary.py
+++ b/tools/automation/tests/test_cost_summary.py
@@ -21,7 +21,10 @@ _RESULT = {
     "num_turns": 7,
     "duration_ms": 65_000,
     "total_cost_usd": 1.25,
-    "result": "I edited the preset overlay. OPENROUTER_API_KEY=sk-or-v1-would-be-here",
+    # A transcript-only marker, deliberately NOT key-shaped: normalization drops the whole
+    # `result` field, so proving it is stripped needs a sentinel, not a real key prefix in a
+    # public repo. Keeps a secret-scanner from flagging a fixture that carries no real value.
+    "result": "I edited the preset overlay. TRANSCRIPT_ONLY_do_not_leak",
     "usage": {
         "input_tokens": 100,
         "output_tokens": 2_000,
@@ -113,7 +116,7 @@ class TestBuildSummary:
 
     def test_the_summary_never_carries_the_transcript_or_the_lifetime_usage(self, tmp_path):
         text = json.dumps(cs.build_summary(_obs_dir(tmp_path)))
-        assert "sk-or-v1" not in text and "I edited" not in text
+        assert "TRANSCRIPT_ONLY" not in text and "I edited" not in text
         assert "usage_usd" not in text  # only deltas + snapshot timestamps
         assert json.loads(text)["key_usage"]["snapshots"]["key_end"] == {"at": "t2"}
 
@@ -247,7 +250,9 @@ class TestKeySnapshot:
     ):
         payload = {
             "data": {
-                "label": "sk-or-v1-abc...def",
+                # OpenRouter's label is the masked key; a non-key-shaped stand-in here proves it
+                # is dropped without putting a key prefix in a public repo.
+                "label": "redacted-masked-key-label",
                 "usage": 1891.41,
                 "usage_daily": 0,
                 "limit": 750,
@@ -328,4 +333,4 @@ def test_run_digest_writes_the_normalized_event_without_the_transcript(tmp_path,
     assert capsys.readouterr().out.startswith("agent_iter_4.jsonl: subtype=success")
     normalized = json.loads(out.read_text())
     assert normalized["iteration"] == 4 and normalized["total_cost_usd"] == 1.25
-    assert "result" not in normalized and "sk-or-v1" not in out.read_text()
+    assert "result" not in normalized and "TRANSCRIPT_ONLY" not in out.read_text()

--- a/tools/automation/tests/test_cost_summary.py
+++ b/tools/automation/tests/test_cost_summary.py
@@ -1,0 +1,331 @@
+"""Unit tests for ``automation.cost_summary``: the three claude -p output shapes, the
+aggregate walk, the key-usage deltas (kept in their own dir), the route caveat, what the
+uploadable shapes may contain, and the two renderings. The HTTP snapshot is exercised
+against a fake ``urlopen``; the workflow wiring is not."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import automation.cost_summary as cs
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RESULT = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": False,
+    "num_turns": 7,
+    "duration_ms": 65_000,
+    "total_cost_usd": 1.25,
+    "result": "I edited the preset overlay. OPENROUTER_API_KEY=sk-or-v1-would-be-here",
+    "usage": {
+        "input_tokens": 100,
+        "output_tokens": 2_000,
+        "cache_read_input_tokens": 90_000,
+        "cache_creation_input_tokens": 3_000,
+    },
+}
+
+
+class TestParseAgentResult:
+    def test_a_single_result_object(self):
+        assert cs.parse_agent_result(json.dumps(_RESULT))["num_turns"] == 7
+
+    def test_the_verbose_array_yields_its_result_event(self):
+        text = json.dumps([{"type": "system", "subtype": "init"}, {"type": "assistant"}, _RESULT])
+        assert cs.parse_agent_result(text)["total_cost_usd"] == 1.25
+
+    def test_stream_json_yields_the_last_result_line(self):
+        lines = [
+            json.dumps({"type": "system", "subtype": "init"}),
+            "not json at all",
+            json.dumps({"type": "assistant", "message": {}}),
+            json.dumps({**_RESULT, "total_cost_usd": 0.5}),
+        ]
+        assert cs.parse_agent_result("\n".join(lines))["total_cost_usd"] == 0.5
+
+    @pytest.mark.parametrize(
+        "text",
+        ["", "   ", "garbage", json.dumps([{"type": "assistant"}]), json.dumps({"error": "x"})],
+    )
+    def test_nothing_usable_is_none(self, text):
+        # Includes an object WITHOUT type: "result" - a `{"error": ...}` body is not a run.
+        assert cs.parse_agent_result(text) is None
+
+
+def _write(path: Path, payload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) if not isinstance(payload, str) else payload)
+
+
+def _snapshots(key_dir: Path) -> None:
+    _write(key_dir / "key_start.json", {"at": "t0", "usage_usd": 100.0})
+    _write(key_dir / "key_after_observe.json", {"at": "t1", "usage_usd": 104.0})
+    _write(key_dir / "key_end.json", {"at": "t2", "usage_usd": 106.5})
+
+
+def _obs_dir(tmp_path: Path, *, snapshots: bool = True, route: str | None = None) -> Path:
+    obs = tmp_path / "observation"
+    _write(obs / "manifest.json", {"candidate": {"name": "x/model"}, "pr": 12})
+    _write(
+        obs / "wire_probes_1" / "aggregate.json", {"total_cost_usd": 2.0, "total_prompt_tokens": 10}
+    )
+    _write(
+        obs / "resolve" / "reprobe_1" / "wire_probes_2" / "aggregate.json",
+        {"total_cost_usd": 0.5, "total_prompt_tokens": 5},
+    )
+    _write(obs / "resolve" / "agent_iter_1.jsonl", json.dumps(_RESULT))
+    _write(obs / "resolve" / "agent_iter_2.jsonl", "no result here")
+    _write(
+        obs / "resolve" / "agent_finalize.jsonl", json.dumps({**_RESULT, "total_cost_usd": 0.75})
+    )
+    if snapshots:
+        _snapshots(obs / "cost")
+    if route:
+        _write(obs / "cost" / "route.txt", route + "\n")
+    return obs
+
+
+class TestBuildSummary:
+    def test_agents_wire_and_key_deltas_are_attributed(self, tmp_path):
+        summary = cs.build_summary(_obs_dir(tmp_path), run_url="https://run")
+
+        agents = summary["agents"]
+        assert agents["runs"] == 3 and agents["runs_parsed"] == 2
+        assert agents["total_cost_usd"] == 2.0  # 1.25 + 0.75; the unparsed run counts as 0
+        assert agents["total_turns"] == 14
+        assert agents["usage"]["cache_read_input_tokens"] == 180_000
+        assert [i["iteration"] for i in agents["iterations"]] == [1, 2]
+        assert summary["wire_probes"]["observe"]["total_cost_usd"] == 2.0
+        assert summary["wire_probes"]["reprobe"]["total_cost_usd"] == 0.5
+        deltas = summary["key_usage"]["deltas_usd"]
+        assert deltas == {"observe": 4.0, "resolve_finalize": 2.5, "total": 6.5}
+        assert summary["totals_usd"]["attributed"] == 4.5
+        assert summary["totals_usd"]["measured_key_delta"] == 6.5
+        assert summary["candidate"] == {"name": "x/model"}
+        assert summary["route"] == "openrouter"
+        assert summary["noteworthy"] is True
+        assert any("no parseable result" in note for note in summary["notes"])
+
+    def test_the_summary_never_carries_the_transcript_or_the_lifetime_usage(self, tmp_path):
+        text = json.dumps(cs.build_summary(_obs_dir(tmp_path)))
+        assert "sk-or-v1" not in text and "I edited" not in text
+        assert "usage_usd" not in text  # only deltas + snapshot timestamps
+        assert json.loads(text)["key_usage"]["snapshots"]["key_end"] == {"at": "t2"}
+
+    def test_snapshots_live_in_their_own_dir(self, tmp_path):
+        obs = _obs_dir(tmp_path, snapshots=False)
+        key_dir = tmp_path / "runner-temp" / "cost"
+        _snapshots(key_dir)
+        summary = cs.build_summary(obs, key_dir=key_dir)
+        assert summary["totals_usd"]["measured_key_delta"] == 6.5
+
+    def test_missing_snapshots_leave_deltas_none_and_say_so(self, tmp_path):
+        summary = cs.build_summary(_obs_dir(tmp_path, snapshots=False))
+        assert summary["key_usage"]["deltas_usd"] == {
+            "observe": None,
+            "resolve_finalize": None,
+            "total": None,
+        }
+        assert summary["totals_usd"]["measured_key_delta"] is None
+        assert any("snapshot is missing" in note for note in summary["notes"])
+
+    def test_iterations_sort_by_number_not_by_name(self, tmp_path):
+        obs = tmp_path / "observation"
+        for n in range(1, 13):
+            _write(
+                obs / "resolve" / f"agent_iter_{n}.jsonl", json.dumps({**_RESULT, "num_turns": n})
+            )
+        agents = cs.build_summary(obs)["agents"]
+        assert [i["iteration"] for i in agents["iterations"]] == list(range(1, 13))
+        assert [i["num_turns"] for i in agents["iterations"]] == list(range(1, 13))
+        md = cs.render_markdown(cs.build_summary(obs))
+        assert md.index("Resolve agent iter 9 ") < md.index("Resolve agent iter 10 ")
+        assert "Resolve agent iter 12 (12 turns, success)" in md
+
+    def test_the_gateway_route_is_named_and_the_observe_delta_is_not_a_probe_cost(self, tmp_path):
+        summary = cs.build_summary(_obs_dir(tmp_path, route="litellm"))
+        assert summary["route"] == "litellm"
+        assert any("route=litellm" in note for note in summary["notes"])
+        assert "agent only; probes billed the gateway key" in cs.render_line(summary)
+        assert "| key delta | n/a (billed on the gateway key) |" in cs.render_markdown(summary)
+
+    def test_an_observe_only_run_attributes_the_whole_delta_to_observe(self, tmp_path):
+        """observe -> needs-human: no gateway step, so no after-observe snapshot and no agent."""
+        obs = tmp_path / "observation"
+        _write(obs / "wire_probes_1" / "aggregate.json", {"total_cost_usd": 2.0})
+        _write(obs / "cost" / "key_start.json", {"at": "t0", "usage_usd": 100.0})
+        _write(obs / "cost" / "key_end.json", {"at": "t2", "usage_usd": 107.0})
+        summary = cs.build_summary(obs)
+        assert summary["key_usage"]["deltas_usd"] == {
+            "observe": 7.0,
+            "resolve_finalize": None,
+            "total": 7.0,
+        }
+        assert any("resolve did not run" in note for note in summary["notes"])
+        assert "| key delta | \\$7.0000 |" in cs.render_markdown(summary)
+
+    def test_unpriced_wire_runs_are_counted_and_said(self, tmp_path):
+        obs = tmp_path / "observation"
+        _write(obs / "wire_probes_1" / "aggregate.json", {"total_cost_usd": None})
+        _write(obs / "wire_probes_2" / "aggregate.json", {"total_cost_usd": 1.0})
+        summary = cs.build_summary(obs)
+        assert summary["wire_probes"]["observe"] == {
+            "runs": 2,
+            "unpriced_runs": 1,
+            "total_cost_usd": 1.0,
+            "tokens": {"prompt": 0, "completion": 0, "cached": 0},
+        }
+        assert any("1 wire run(s) carry no cost" in note for note in summary["notes"])
+
+    def test_a_run_that_ran_agents_is_noteworthy_even_with_no_figures(self, tmp_path):
+        obs = tmp_path / "observation"
+        _write(obs / "resolve" / "agent_iter_1.jsonl", "cut off before any result event")
+        assert cs.build_summary(obs)["noteworthy"] is True
+
+    def test_an_empty_observation_dir_is_all_zeros_and_not_noteworthy(self, tmp_path):
+        summary = cs.build_summary(tmp_path)
+        assert summary["agents"]["runs"] == 0
+        assert summary["totals_usd"]["attributed"] == 0.0
+        assert summary["noteworthy"] is False
+
+    def test_a_download_with_only_normalized_events_still_has_the_agents(self, tmp_path):
+        obs = tmp_path / "observation"
+        _write(
+            obs / "cost" / "agent_iter_3.json",
+            cs.normalize_agent_result(_RESULT, file="agent_iter_3.jsonl", iteration=3),
+        )
+        agents = cs.build_summary(obs)["agents"]
+        assert agents["runs"] == 1 and agents["total_cost_usd"] == 1.25
+        assert agents["iterations"][0]["iteration"] == 3
+
+
+class TestRendering:
+    def test_the_line_leads_with_the_billed_figure_when_known(self, tmp_path):
+        line = cs.render_line(cs.build_summary(_obs_dir(tmp_path)))
+        assert line.startswith("Cost: $6.5000 billed on the automation key - agents $2.0000")
+        assert "over 14 turns in 3 run(s), wire probes $2.5000" in line
+        assert "\n" not in line
+
+    def test_the_line_falls_back_to_the_attributed_lower_bound(self, tmp_path):
+        line = cs.render_line(cs.build_summary(_obs_dir(tmp_path, snapshots=False)))
+        assert line.startswith("Cost: >= $4.5000 attributed (key delta unavailable)")
+
+    def test_the_markdown_has_one_row_per_stage_escapes_dollars_and_lists_the_notes(self, tmp_path):
+        md = cs.render_markdown(cs.build_summary(_obs_dir(tmp_path), run_url="https://run"))
+        assert md.startswith("### Cost summary - `x/model`")
+        assert "| Resolve agent iter 1 (7 turns, success) | CLI self-report | \\$1.2500 |" in md
+        assert "| Resolve agent iter 2 (? turns, unparsed) | CLI self-report | n/a |" in md
+        assert "| Finalize agent (7 turns, success) | CLI self-report | \\$0.7500 |" in md
+        assert "| **Total billed** (key delta) | | **\\$6.5000** |" in md
+        assert "cache read 180,000" in md
+        assert "candidate's wire calls only" in md
+        assert "[Run](https://run)" in md
+        # No unescaped dollar anywhere: GitHub would render `$a ... $b` as math.
+        assert "$" not in md.replace("\\$", "")
+
+    def test_the_digest_line_names_how_the_run_ended(self):
+        assert cs.digest_line(None, label="a.jsonl").startswith("a.jsonl: no result event")
+        line = cs.digest_line({**_RESULT, "subtype": "error_max_turns"}, label="b.jsonl")
+        assert "subtype=error_max_turns" in line and "turns=7" in line and "cost=$1.2500" in line
+
+
+class TestKeySnapshot:
+    class _Response(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.close()
+
+    def test_it_writes_the_usage_figure_and_nothing_that_identifies_the_key(
+        self, tmp_path, monkeypatch
+    ):
+        payload = {
+            "data": {
+                "label": "sk-or-v1-abc...def",
+                "usage": 1891.41,
+                "usage_daily": 0,
+                "limit": 750,
+                "limit_remaining": 750,
+            }
+        }
+        monkeypatch.setattr(
+            cs.urllib.request,
+            "urlopen",
+            lambda request, timeout: self._Response(json.dumps(payload).encode()),
+        )
+        out = tmp_path / "cost" / "key_start.json"
+        assert cs.snapshot_key(out, api_key="k") is True
+        written = json.loads(out.read_text())
+        assert set(written) == {"at", "usage_usd"} and written["usage_usd"] == 1891.41
+        assert cs.read_key_snapshot(out)["usage_usd"] == 1891.41
+
+    def test_no_key_means_no_file_and_no_failure(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        out = tmp_path / "key.json"
+        assert cs.snapshot_key(out) is False
+        assert not out.exists()
+        assert cs.run_key_snapshot(str(out)) == 0
+
+    def test_a_network_error_and_a_bad_payload_are_swallowed(self, tmp_path, monkeypatch):
+        def boom(request, timeout):
+            raise OSError("down")
+
+        monkeypatch.setattr(cs.urllib.request, "urlopen", boom)
+        assert cs.snapshot_key(tmp_path / "key.json", api_key="k") is False
+        monkeypatch.setattr(
+            cs.urllib.request,
+            "urlopen",
+            lambda request, timeout: self._Response(json.dumps({"data": {}}).encode()),
+        )
+        assert cs.snapshot_key(tmp_path / "key.json", api_key="k") is False
+
+
+def test_run_writes_json_markdown_and_line(tmp_path, capsys):
+    obs = _obs_dir(tmp_path, snapshots=False)
+    key_dir = tmp_path / "runner-temp" / "cost"
+    _snapshots(key_dir)
+    code = cs.run(
+        str(obs),
+        out=str(obs / "cost" / "cost_summary.json"),
+        md_out=str(obs / "cost" / "cost_summary.md"),
+        line_out=str(obs / "cost" / "cost_summary.txt"),
+        run_url="https://run",
+        key_dir=str(key_dir),
+    )
+    assert code == 0
+    assert json.loads((obs / "cost" / "cost_summary.json").read_text())["schema_version"] == 1
+    assert (obs / "cost" / "cost_summary.md").read_text().startswith("### Cost summary")
+    assert (obs / "cost" / "cost_summary.txt").read_text().startswith("Cost: $6.5000")
+    assert capsys.readouterr().out.startswith("Cost: $6.5000")
+
+
+def test_run_writes_only_the_json_when_nothing_was_spent(tmp_path, capsys):
+    obs = tmp_path / "observation"
+    obs.mkdir()
+    cs.run(
+        str(obs),
+        out=str(obs / "cost" / "cost_summary.json"),
+        md_out=str(obs / "cost" / "cost_summary.md"),
+        line_out=str(obs / "cost" / "cost_summary.txt"),
+    )
+    assert (obs / "cost" / "cost_summary.json").exists()
+    assert not (obs / "cost" / "cost_summary.md").exists()
+    assert not (obs / "cost" / "cost_summary.txt").exists()
+    assert "nothing spent on record" in capsys.readouterr().out
+
+
+def test_run_digest_writes_the_normalized_event_without_the_transcript(tmp_path, capsys):
+    raw = tmp_path / "resolve" / "agent_iter_4.jsonl"
+    _write(raw, json.dumps({"type": "system"}) + "\n" + json.dumps(_RESULT))
+    out = tmp_path / "cost" / "agent_iter_4.json"
+    assert cs.run_digest(str(raw), out=str(out)) == 0
+    assert capsys.readouterr().out.startswith("agent_iter_4.jsonl: subtype=success")
+    normalized = json.loads(out.read_text())
+    assert normalized["iteration"] == 4 and normalized["total_cost_usd"] == 1.25
+    assert "result" not in normalized and "sk-or-v1" not in out.read_text()


### PR DESCRIPTION
## What

Every auto-integration run now ends with an accounting tail once the candidate is known, whatever the outcome: `automation cost-summary` writes `observation/cost/cost_summary.{json,md,txt}`, posts the markdown as a PR comment, sends the one-liner to the Slack thread (new icon role `cost_summary`, no mention) and uploads the `integration-cost-pr<N>` artifact. Three sources, kept apart because they measure different things:

| Source | Covers | What the number is |
|---|---|---|
| the `claude -p` result event of every resolve iteration and the finalize run (the agent calls now run with `--verbose --output-format stream-json \| tee observation/resolve/agent_*.jsonl`) | the agent | the CLI's own report at Anthropic list price; cache writes are not surfaced on the gateway route, so a lower bound |
| `wire_probes_*/aggregate.json` (observe) and `resolve/reprobe_*/` (reprobe) | the candidate's wire calls only | exact for what it covers; the capability + variant probes and the user simulator leave no cost artifact |
| `automation key-snapshot` (OpenRouter `GET /api/v1/key`) at run start, after observe and at the end | everything billed on `ARENA_AUTOMATION_OPENROUTER_API_KEY`, probes included | the billed figure; key-level, so a concurrent run on the same key is included |

On the `litellm` route the probes bill the gateway key, so the `.env` step records the effective route in `observation/cost/route.txt` and the summary labels the key deltas as agent-only.

## What leaves the runner

Only the summary and the **normalized** agent result events (`observation/cost/agent_*.json`: cost, turns, usage, how the run ended), written by `automation agent-digest <file> --out`. Never the raw transcripts: a `Bash(env)` or `cat .env` tool result in them would carry the run's keys, and GitHub masks the job log, not an artifact of a public repo. The key snapshots hold the key's lifetime usage figure, so they live in `$RUNNER_TEMP/cost` and only their deltas reach the summary (`cost-summary --key-dir`).

## Invariants

- Accounting can never fail the integration: every call is `|| true`, both new steps are `continue-on-error`, `key-snapshot` exits 0 on any miss, and a run with nothing spent on record writes the JSON but no md/txt, so nothing is posted.
- The key reaches `uv run automation` in the tail step under the same accepted-risk envelope as the existing post-agent `automation reprobe` calls (documented in the workflow).
- The key is read through `SecretManager([EnvProvider()])` (env-only, the same way `gateway_catalog.py` does it), never `os.environ` directly.
- On an observe -> needs-human run there is no after-observe snapshot (the gateway step is gated on a clean observe), so the summary attributes the whole key delta to observe and says so; wire aggregates with `total_cost_usd: null` (no pricing) are counted and noted rather than read as zero.

## Trade-off

The agent transcript in the job log is now one JSON event per line (stream-json) instead of the `--verbose` text rendering; `automation agent-digest` prints a one-line digest (subtype, turns, cost) per run so the log still says how a run ended.

## Verification

- `tools/automation/tests`: 306 passed (new `test_cost_summary.py`; `test_icons` checks every `--icon` role used in the workflow is declared and used).
- `ruff check` + `black --check` clean on the touched files; the workflow parses.
- Two independent review rounds; round 1 found the transcript-in-artifact exposure, the litellm-route under-report and the snapshot privacy issue, all fixed.

Not run: a live integration (needs a candidate PR); `actionlint` locally (runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
