### PR TITLE
docs(adapters): consolidate third-party adapter author's adoption path (#1395)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ examples/             # Reference task layouts with runnable run_config.yaml
 | Coding-harness mode (vendor CLIs) | [docs/CODING_HARNESSES.md](docs/CODING_HARNESSES.md) |
 | Running terminal-bench (harness + engine loop) | [docs/RUNNING_TERMINAL_BENCH.md](docs/RUNNING_TERMINAL_BENCH.md) |
 | Adapter architecture | [docs/ADAPTER_ARCHITECTURE.md](docs/ADAPTER_ARCHITECTURE.md) |
+| Adapter interface reference | [docs/ADAPTER_INTERFACE.md](docs/ADAPTER_INTERFACE.md) |
+| Authoring an adapter (third-party package walkthrough) | [docs/AUTHORING_AN_ADAPTER.md](docs/AUTHORING_AN_ADAPTER.md) |
+| Native adapter deep reference | [docs/NATIVE_ADAPTER.md](docs/NATIVE_ADAPTER.md) |
 | Analytics & failure attribution | [docs/ANALYTICS.md](docs/ANALYTICS.md) |
 | Python package API | [docs/PYTHON_PACKAGE.md](docs/PYTHON_PACKAGE.md) |
 | Task packs | [docs/TASK_PACKS.md](docs/TASK_PACKS.md) |

--- a/docs/ADAPTER_ARCHITECTURE.md
+++ b/docs/ADAPTER_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 Adapters provide a unified interface for loading tasks and environments from different sources.
 
-For contributor-facing contract details, see `docs/ADAPTER_INTERFACE.md`.
+For contributor-facing contract details, see `docs/ADAPTER_INTERFACE.md`. For the end-to-end adoption walkthrough that consumes this architecture, see [AUTHORING_AN_ADAPTER.md](AUTHORING_AN_ADAPTER.md).
 
 ## Adapter families
 

--- a/docs/ADAPTER_INTERFACE.md
+++ b/docs/ADAPTER_INTERFACE.md
@@ -1,5 +1,7 @@
 # Adapter Interface Contract
 
+For the end-to-end adoption walkthrough that consumes this contract, see [AUTHORING_AN_ADAPTER.md](AUTHORING_AN_ADAPTER.md).
+
 This document defines the extension contract for adding new adapter backends. For the accepted-record on the `AdapterGradingContract` structural Protocol and the three capability flags on `BaseAdapter` (`requires_docker_cli_in_runner`, `grades_from_task_grading_file`, `syncs_adapter_env_to_state`), see [ADR-0043 — Detached-mode grader, typed grader kinds, adapter grading contract](adr/0043-detached-mode-grader-and-typed-grader-kinds.md).
 
 ## Plugin Registration
@@ -215,7 +217,7 @@ otherwise infer from adapter identity. Each default is `False` on
 ### AdapterGradingContract
 
 The Protocol at `tolokaforge.adapters.AdapterGradingContract` names the six
-grading methods (items 13 - 16, 18 - 20) plus the three capability flags as
+grading methods (items 14 - 16, 18 - 20) plus the three capability flags as
 one addressable contract. `BaseAdapter` satisfies it structurally through
 the defaults documented above, so every adapter shipping today matches
 without changing shape. External adapters can import it for a

--- a/docs/AUTHORING_AN_ADAPTER.md
+++ b/docs/AUTHORING_AN_ADAPTER.md
@@ -150,10 +150,9 @@ holds structurally for any subclass of `BaseAdapter`.
 
 **Explicit exclusion.** Item 13 (`grading_hash_source_layer`) is **not** a
 member of `AdapterGradingContract` — it is a classmethod default on
-`BaseAdapter`. Step 2 above is where you override it. This is the item-range
-correction the sibling
+`BaseAdapter`. Step 2 above is where you override it. The sibling
 [`docs/ADAPTER_INTERFACE.md § AdapterGradingContract`](ADAPTER_INTERFACE.md#adaptergradingcontract)
-section names.
+section names the same six items (14 – 16 and 18 – 20).
 
 Under an active coding harness, `preferred_grader_kind()` alignment with the
 `grading_method` `emit_test_execution_grading()` puts on the emitted

--- a/docs/AUTHORING_AN_ADAPTER.md
+++ b/docs/AUTHORING_AN_ADAPTER.md
@@ -1,0 +1,296 @@
+# Authoring a TolokaForge Adapter
+
+An **adapter** is a task loader that translates a source format the engine does
+not read natively (a tau-bench pack, a terminal-bench directory, a proprietary
+JSON layout) into the `TaskConfig` / `AdapterEnvironment` shape the engine
+orchestrates against. You write one when you want to run TolokaForge against a
+benchmark whose on-disk layout is not `task.yaml` + `grading.yaml`. A
+**third-party adapter** is a separate pip-installable Python package that
+depends on `tolokaforge` and registers itself through the
+`tolokaforge.adapters` entry-point group; the engine discovers it at import
+time and everything downstream of `get_adapter(<name>)` sees a first-class
+citizen.
+
+This document is the ordered top-of-funnel walkthrough. Follow the eight steps
+in order and you end with a registered, tested, CI-covered adapter package.
+Each step names the identifier a reader would grep for and links out to the
+deep-dive doc for the concern the step raises. Do not duplicate deep-dive
+content back into this doc; open the linked section instead.
+
+## The eight-step checklist
+
+### 1. Scaffold the package
+
+A minimum `pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tolokaforge-adapter-my-benchmark"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["tolokaforge"]
+
+[project.entry-points."tolokaforge.adapters"]
+my_benchmark = "tolokaforge_adapter_my_benchmark.adapter:MyBenchmarkAdapter"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tolokaforge_adapter_my_benchmark"]
+```
+
+The shape mirrors the shipped
+[`external_adapters/tolokaforge-adapter-terminal-bench/pyproject.toml`](../external_adapters/tolokaforge-adapter-terminal-bench/pyproject.toml).
+`tolokaforge` is a hard dependency: the entry-point cannot load otherwise, and
+step 6's reusable test suite is imported from it.
+
+### 2. Subclass `BaseAdapter`
+
+Implement the ten required methods (`get_task_ids`, `get_task`,
+`get_task_dir`, `create_environment`, `get_tools`, `get_registry_tools`,
+`get_system_prompt`, `get_grading_config`, `reset_environment`,
+`compute_golden_hash`) — deep signatures live in
+[`docs/ADAPTER_INTERFACE.md § Required Methods`](ADAPTER_INTERFACE.md#required-methods),
+items 1 – 10.
+
+Then consider four **optional overrides** that live on `BaseAdapter` and are
+**not** members of `AdapterGradingContract` (step 4 covers the Protocol
+methods; these are addressed here because they ride on the base class):
+
+- `convert_to_native(task_id) -> NativeTaskBundle` (item 11) — emit a native
+  `task.yaml` + `grading.yaml` bundle for disk serialisation. Default raises
+  `NotImplementedError`; override only when downstream tooling reads the
+  native bundle.
+- `grading_combine_layer() -> CombineLayer` (item 12) — what your projects
+  supply beneath a task's own `combine` block. Default:
+  `CombineLayer.unresolvable()`.
+- `grading_hash_source_layer(task, task_dir) -> HashSourceLayer` (item 13) —
+  a **classmethod**. What you supply beneath a task's authored
+  `state_checks.hash` block. Default: `HashSourceLayer.unresolvable()`.
+- `fingerprint() -> dict[str, Any] | None` (item 17) — the payload the engine
+  writes under `adapter_fingerprints[<adapter type>]` on
+  `engine_run_state.json`. Default: `None`.
+
+If the tasks stand up a compose stack, also override
+`docker_stack_requirements() -> DockerStackRequirements` — see
+[`docs/ADAPTER_INTERFACE.md § Docker stack requirements`](ADAPTER_INTERFACE.md#docker-stack-requirements).
+
+If the adapter drives a coding-harness CLI (`claude-code`, `codex`,
+`kimi-code`, …), mix in
+[`CodingHarnessAdapterMixin`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py)
+alongside `BaseAdapter`. The mixin flips `supports_coding_harness = True`
+(the gate the orchestrator's config-validation reads) and ships seven helpers
+covering registry resolution, command assembly, the metadata handshake, the
+bash tool schema payload, the `test_execution` grading payload, the
+standalone install-script Dockerfile layer, and — load-bearing on step 6 —
+the instance-aware `preferred_grader_kind()` default. That default is exactly
+what step 6's `expected_preferred_grader_kind` fixture locks against under an
+active harness. See
+[`tolokaforge_coding_harnesses/README.md § Adopting the mixin`](../tolokaforge_coding_harnesses/README.md#adopting-the-mixin).
+
+### 3. Declare capability flags
+
+Three `ClassVar[bool]` slots on the class body sit atop `BaseAdapter`'s
+`False` default. Flip only what applies:
+
+```python
+class MyBenchmarkAdapter(BaseAdapter):
+    requires_docker_cli_in_runner: ClassVar[bool] = False
+    grades_from_task_grading_file: ClassVar[bool] = False
+    syncs_adapter_env_to_state: ClassVar[bool] = False
+```
+
+- `requires_docker_cli_in_runner` — flip to `True` when grading runs commands
+  against Docker daemons (build/exec); the harness reads the flag to decide
+  whether the runner stack must carry a Docker socket bind.
+- `grades_from_task_grading_file` — flip to `True` when the adapter grades
+  from a `grading:` block a task names on disk. Native-shaped adapters flip
+  this; adapters that synthesise grading config from their own fixtures leave
+  it `False`. The `grading:` presence gate reads the flag to decide whether
+  an absent block is refused or an unchecked pronouncement.
+- `syncs_adapter_env_to_state` — flip to `True` when the conductor should
+  sync `AdapterEnvironment` into runner state (Tau-family); adapters whose
+  runner owns state end-to-end leave it `False`.
+
+Deep contract:
+[`docs/ADAPTER_INTERFACE.md § Capability flags`](ADAPTER_INTERFACE.md#capability-flags).
+
+### 4. Override the six `AdapterGradingContract` method slots
+
+The Protocol at
+[`tolokaforge.adapters.AdapterGradingContract`](../tolokaforge/adapters/grading_contract.py)
+declares exactly six methods, mapped to the numbered list in
+[`docs/ADAPTER_INTERFACE.md § Optional Methods`](ADAPTER_INTERFACE.md#optional-methods):
+
+- `grading_tool_inventory(task, task_dir) -> ToolInventory` (item 14) — the
+  tool set this adapter presents at runtime. Default:
+  `ToolInventory.unresolvable()`.
+- `grading_replay_world(task, task_dir) -> ReplayWorld` (item 15) — the
+  initial-state + `mcp_server` a golden-action replay executes against.
+  Default: `ReplayWorld.unresolvable()`.
+- `grading_seeded_tables(task, task_dir) -> SeededTablesLayer` (item 16) —
+  the tables this adapter seeds, keyed by `state_checks.id_fields`. Default:
+  `SeededTablesLayer.unresolvable()`.
+- `grading_source(task, task_dir) -> GradingSource` (item 18) — the grading
+  block one run of *task* reads, resolved against this adapter. Default:
+  `GradingSourceKind.UNINTERROGABLE` with `path=None` and a non-empty
+  reason.
+- `emit_runner_grading_payload(task_id) -> dict[str, Any]` (item 19) — the
+  payload this adapter emits for the runner's `RunnerGradingConfig`
+  construction. Default: `{}`.
+- `preferred_grader_kind() -> str` (item 20) — the registered
+  `tolokaforge.grader_kinds` key this adapter prefers. Default:
+  `"composite"`.
+
+Override only the slots whose default your adapter diverges from. The
+Protocol is `runtime_checkable`, so `isinstance(adapter, AdapterGradingContract)`
+holds structurally for any subclass of `BaseAdapter`.
+
+**Explicit exclusion.** Item 13 (`grading_hash_source_layer`) is **not** a
+member of `AdapterGradingContract` — it is a classmethod default on
+`BaseAdapter`. Step 2 above is where you override it. This is the item-range
+correction the sibling
+[`docs/ADAPTER_INTERFACE.md § AdapterGradingContract`](ADAPTER_INTERFACE.md#adaptergradingcontract)
+section names.
+
+Under an active coding harness, `preferred_grader_kind()` alignment with the
+`grading_method` `emit_test_execution_grading()` puts on the emitted
+`RunnerGradingConfig` is the load-bearing invariant. See
+[`docs/CODING_HARNESSES.md § Grader-kind alignment`](CODING_HARNESSES.md#grader-kind-alignment).
+
+### 5. Register the entry-point
+
+The `[project.entry-points."tolokaforge.adapters"]` block from step 1 is what
+makes the engine discover the class. The registered name (`my_benchmark`
+above) is the string a run config's `harness_adapter.type` reads:
+
+```yaml
+evaluation:
+  harness_adapter:
+    type: "my_benchmark"
+```
+
+Duplicate-name (two installed distributions registering the same key) and
+broken-import (an entry-point whose target module raises on load) fail-loud
+semantics live in
+[`docs/ADAPTER_ARCHITECTURE.md § Fail-loud registry pattern`](ADAPTER_ARCHITECTURE.md#fail-loud-registry-pattern).
+Both are handled by the shared
+`tolokaforge.core.plugin_registry.discover_entry_points` primitive; the
+adapter package does not implement its own scan.
+
+### 6. Pin conformance with `AdapterGradingContractSuite`
+
+Subclass
+[`AdapterGradingContractSuite`](../tolokaforge/testing/adapters/grading_contract.py)
+from `tolokaforge.testing.adapters` and hand it two fixtures. The subclass
+runs 13 test methods against those fixtures — the six
+`AdapterGradingContract` methods from step 4, the three capability flags
+from step 3, three cross-cutting invariants (`grading_source` classmethod-
+dispatch parity, emit-payload schema, preferred-kind registry resolution),
+and one alignment invariant (`preferred_grader_kind()` equals the kind
+`emit_test_execution_grading()` puts on `RunnerGradingConfig` under an
+active harness).
+
+```python
+import pytest
+from tolokaforge.core.models import TaskConfig
+from tolokaforge.testing.adapters import AdapterGradingContractSuite
+
+from tolokaforge_adapter_my_benchmark.adapter import MyBenchmarkAdapter
+
+
+class TestMyBenchmarkAdapterGradingContract(AdapterGradingContractSuite):
+    expected_requires_docker_cli_in_runner = True
+    expected_preferred_grader_kind = "test_execution"
+
+    @pytest.fixture
+    def adapter(self) -> MyBenchmarkAdapter:
+        return MyBenchmarkAdapter({"base_dir": ".", "tasks_glob": "tasks/*"})
+
+    @pytest.fixture
+    def task_and_dir(self, adapter: MyBenchmarkAdapter) -> tuple[TaskConfig, Path]:
+        task_id = adapter.get_task_ids()[0]
+        return adapter.get_task(task_id), adapter.get_task_dir(task_id)
+```
+
+Override the four `expected_*` class attributes only when your adapter's
+declaration diverges from the shipped defaults:
+
+- `expected_requires_docker_cli_in_runner: bool = False`
+- `expected_grades_from_task_grading_file: bool = False`
+- `expected_syncs_adapter_env_to_state: bool = False`
+- `expected_preferred_grader_kind: str = "composite"`
+
+When step 2 mixed in `CodingHarnessAdapterMixin`, the mixin's instance-aware
+`preferred_grader_kind()` default is exactly what
+`expected_preferred_grader_kind` locks against — set it to
+`"test_execution"` on adapters whose harness-mode grading writes a reward
+file, matching the mixin's return under `self.agent_harness != ENGINE_LOOP`.
+
+Deep contract:
+[`docs/ADAPTER_INTERFACE.md § AdapterGradingContractSuite`](ADAPTER_INTERFACE.md#adaptergradingcontractsuite-reusable-pytest-suite).
+Worked example:
+[`external_adapters/tolokaforge-adapter-terminal-bench/tests/test_terminal_bench_grading_contract.py`](../external_adapters/tolokaforge-adapter-terminal-bench/tests/test_terminal_bench_grading_contract.py).
+
+### 7. Install and run tests locally
+
+Install the adapter into a venv that already has `tolokaforge` and run the
+test suite:
+
+```bash
+pip install -e .
+pytest tests/
+```
+
+The engine dependency in `pyproject.toml` (declared in step 1) is what
+lets the entry-point resolve and the suite import land. If the suite raises
+`ModuleNotFoundError: tolokaforge`, the venv is missing the engine and the
+entry-point cannot have been discovered either.
+
+### 8. Wire CI
+
+The adapter package's CI runs the same command as step 7:
+
+```yaml
+- name: Test adapter
+  run: pytest tests/
+```
+
+Because the suite subclass ships inside the adapter repository, an upstream
+engine change that breaks any of the 13 pinned invariants (a new required
+`AdapterGradingContract` slot, a tightened capability-flag semantics, a
+grader-kind registration rename) fails the adapter's CI on the next
+`tolokaforge` dependency bump — not on the next real run. Pin the engine
+loosely (`tolokaforge>=X`) in `pyproject.toml` if you want to opt into fast
+drift signal, tightly (`tolokaforge==X.Y.Z`) if you would rather age the
+adapter alongside a specific engine cut.
+
+## What lives elsewhere
+
+| Concern | Deep-dive doc |
+| --- | --- |
+| Method contract (all 20 items, capability flags, Protocol, suite) | [docs/ADAPTER_INTERFACE.md](ADAPTER_INTERFACE.md) |
+| Architecture, entry-point discovery, fail-loud registry, `uv sync --extra <name>` install extras | [docs/ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) |
+| Coding-harness capability (`CodingHarnessAdapterMixin`) | [docs/CODING_HARNESSES.md](CODING_HARNESSES.md), [tolokaforge_coding_harnesses/README.md § Adopting the mixin](../tolokaforge_coding_harnesses/README.md#adopting-the-mixin) |
+| Working out-of-tree adopter | [external_adapters/tolokaforge-adapter-terminal-bench/](../external_adapters/tolokaforge-adapter-terminal-bench/) |
+| Native-adapter deep reference | [docs/NATIVE_ADAPTER.md](NATIVE_ADAPTER.md) |
+
+## Reference implementations
+
+- **`NativeAdapter`** — [`tolokaforge/adapters/native.py`](../tolokaforge/adapters/native.py).
+  Built-in, discovered before the entry-point scan, and the shipped adopter
+  of `CodingHarnessAdapterMixin`. Read it for the canonical shape of every
+  method slot.
+- **`TerminalBenchAdapter`** —
+  [`external_adapters/tolokaforge-adapter-terminal-bench/`](../external_adapters/tolokaforge-adapter-terminal-bench/).
+  The shipped out-of-tree adopter. Its
+  [`pyproject.toml`](../external_adapters/tolokaforge-adapter-terminal-bench/pyproject.toml),
+  [`AdapterGradingContractSuite` subclass](../external_adapters/tolokaforge-adapter-terminal-bench/tests/test_terminal_bench_grading_contract.py),
+  and
+  [README](../external_adapters/tolokaforge-adapter-terminal-bench/README.md)
+  are the worked example this checklist is calibrated against.
+- **`TauAdapter`** / **`TlkMcpCoreAdapter`** — plugin-package adopters
+  shipped alongside the engine. See
+  [`docs/ADAPTER_ARCHITECTURE.md § Adapter-Specific Details`](ADAPTER_ARCHITECTURE.md#adapter-specific-details).

--- a/docs/CODING_HARNESSES.md
+++ b/docs/CODING_HARNESSES.md
@@ -201,6 +201,8 @@ Both are documented in
 
 ## Adopting the mixin in an adapter
 
+Harness adoption is one branch of the general adapter-authoring walkthrough at [AUTHORING_AN_ADAPTER.md § Subclass `BaseAdapter`](AUTHORING_AN_ADAPTER.md#2-subclass-baseadapter) (step 2).
+
 An adapter opts into harness mode by inheriting
 `CodingHarnessAdapterMixin` alongside `BaseAdapter`. The mixin sets
 `supports_coding_harness = True` (which the orchestrator's gate reads)


### PR DESCRIPTION
## Summary

Adds a new authoritative top-of-funnel walkthrough at `docs/AUTHORING_AN_ADAPTER.md` that walks a third-party author from empty repo → registered adapter package in eight steps: scaffold, subclass `BaseAdapter` (+ optional `CodingHarnessAdapterMixin`), capability flags, six `AdapterGradingContract` Protocol methods, entry-point registration, `AdapterGradingContractSuite` subclass, `pip install -e .` + `pytest`, CI wiring. Cross-references the existing deep-dive docs without duplicating their content.

Also fixes a real arithmetic bug at `docs/ADAPTER_INTERFACE.md:220`: the item-range `(items 13 – 16, 18 – 20)` claimed 6 methods but enumerated 7 — item 13 (`grading_hash_source_layer`) is a `BaseAdapter` classmethod (`base.py:317`), not a Protocol member. Corrected to `(items 14 – 16, 18 – 20)`.

Closes #1395.

## Design choices

| Decision | Rationale |
|---|---|
| New `docs/AUTHORING_AN_ADAPTER.md` (not reclaim `docs/ADAPTERS.md`) | `docs/ADAPTERS.md` is a 185-line bug-audit log titled "Adapter Known Issues & Audit Log", not adoption guidance. Renaming would chase 4 existing cross-references and destroy bug history. New file with a distinct name avoids the churn. |
| No CI markdown-link-check | Not landed in the repo today. Reviewer + implementer link-check pass covers this PR; a CI job for future drift is filed as a follow-up. |
| Six Protocol methods enumerated as items 14, 15, 16, 18, 19, 20 | Verified against `tolokaforge/adapters/grading_contract.py:32-55` — `grading_source`, `grading_tool_inventory`, `grading_replay_world`, `grading_seeded_tables`, `emit_runner_grading_payload`, `preferred_grader_kind`. Item 13 (`grading_hash_source_layer`) is on `BaseAdapter`, called out in step 2 with an explicit "not a Protocol member" exclusion note. |
| Step 6 names both inheritance points | Suite subclassing AND `CodingHarnessAdapterMixin.preferred_grader_kind()` default flowing into `expected_preferred_grader_kind` — the alignment invariant #1394 shipped, discoverable from the checklist. |
| No CHANGELOG entry | Docs-only, no user-facing API change. |

## Scope of change

- **NEW** `docs/AUTHORING_AN_ADAPTER.md` — 300-line, 8-step checklist + pointer table + reference implementations (NativeAdapter, TerminalBenchAdapter, external adopters).
- **FIX** `docs/ADAPTER_INTERFACE.md:220` — item-range `(items 13 – 16, 18 – 20)` → `(items 14 – 16, 18 – 20)`.
- **POINTERS** — one line each in `docs/ADAPTER_INTERFACE.md`, `docs/ADAPTER_ARCHITECTURE.md`, `docs/CODING_HARNESSES.md` pointing at the new AUTHORING doc.
- **INDEX** — README.md docs table gains 3 rows: `docs/ADAPTER_INTERFACE.md`, `docs/NATIVE_ADAPTER.md`, `docs/AUTHORING_AN_ADAPTER.md` (closes existing indexing gaps for the first two).

## Test plan

- [x] Every code reference in the new doc verified against source (Protocol shape, item numbers, Suite defaults, mixin helpers, entry-point group name).
- [x] Every markdown link + `#anchor` resolves against the current tree (13 file paths + 10 anchors).
- [x] `docs/ADAPTER_INTERFACE.md:220` post-edit reads `(items 14 – 16, 18 – 20)`.

## Reviewer coverage

- **reviewer-correctness** → APPROVE (every code reference and item-number range verified against source; the `ADAPTER_INTERFACE.md:220` fix is arithmetically sound).
- **reviewer-hygiene** → APPROVE WITH NITS (one Minor: "item-range correction" phrasing at line 151 carried historical residue — rewritten in-place in follow-up commit `cd1901af` to describe current state only).
- Type-fit lane skipped — docs-only PR has no Protocol/type-system surface to review.

## Follow-ups

- To file: `docs/ADAPTERS.md` identity clarification (rename to `ADAPTER_KNOWN_ISSUES.md` or add a top-of-file disambiguation note).
- To file: CI markdown-link-check job so cross-reference drift fails fast on subsequent PRs.