### PR TITLE
docs(skills): fold discovered issues into the source milestone by default

### DIFF
--- a/.agents/skills/executing-development-tickets/SKILL.md
+++ b/.agents/skills/executing-development-tickets/SKILL.md
@@ -97,8 +97,11 @@ Drive your standard planning workflow:
 2. Reproduce the current behaviour by running it: dev MCP run_tests / run_python,
    `make docker-up` for env services, a targeted `tolokaforge run` if the behaviour
    only shows end-to-end. For a bugfix, capture the reproducing failure.
-3. File any out-of-scope "Discovered issues" via the GitHub MCP and reference the
-   numbers in the plan.
+3. File any out-of-scope "Discovered issues" via the GitHub MCP; **when issue #<N>
+   has a milestone, pass `milestone=<that milestone number>` on every filing so
+   follow-ups fold into the same milestone.** Deferral out of the milestone requires
+   a one-sentence rationale in the plan's "Deferred" bullet and label
+   `deferred:M<N>` on the deferred issue. Reference the numbers in the plan.
 4. Write the plan to ~/.claude/plans/toloka-tolokaforge/issue-<N>-<short-name>.md
    (a scratch path outside the repo — plans are never committed to the tree; the
    plan's durable home is the per-issue PR body).
@@ -237,7 +240,7 @@ The "one stage = one commit" contract, the drift-handling rules, and the correct
    - Behaviour-locking test exists: open the file, confirm it exercises real behaviour at the named tier (not mocks), and carries the right pytest marker.
    - Docs updated in the same commit — verify with `git show --stat HEAD`.
    - Verification commands ran cleanly (dev MCP `lint_check` + `format_check`, targeted `run_tests`).
-   - "Discovered issues" surfaced. For each: fix-in-this-PR (note for next stage or follow-up) or `mcp__github__issue_write` to file it.
+   - "Discovered issues" surfaced. For each: fix-in-this-PR (note for next stage or follow-up) or `mcp__github__issue_write` to file it. **When issue #<N> has a milestone, every filed follow-up MUST pass `milestone=<that milestone number>` so it folds into the same milestone.** Deferral out of the milestone requires (a) a one-sentence rationale recorded in the PR body's Discovered-issues section, (b) label `deferred:M<N>` on the deferred issue, and (c) cross-link the source PR + milestone in the deferred issue's body. If you can't decide, ask the user — do not file un-milestoned by default during an active-milestone run.
 3. **Drift handling.**
    - **Justified drift** (the plan was wrong in a way the implementer caught): update the plan file yourself, show the diff to the user, continue.
    - **Unjustified drift** (implementer expanded scope, weakened a check, suppressed a lint, mocked something that should exercise real behaviour): launch a corrective `plan-stage-implementer` with explicit revert instructions. Don't accept the drift silently.
@@ -297,7 +300,7 @@ If the reviewer returns 🔴 Blocker or 🟠 Major findings:
 3. Re-launch the three sharded reviewers (`reviewer-correctness`, `reviewer-hygiene`, `reviewer-type-fit`) in parallel on the updated branch, same as Step 8. Merge findings the same way.
 4. Loop until every lane's verdict is `APPROVE` or `APPROVE WITH NITS`. **Cap: 2 fix rounds.** If any lane keeps finding the same Blocker, stop and ask the user — don't grind the implementer.
 
-Nit / Minor findings: surface to the user as optional follow-ups; don't block the PR on them.
+Nit / Minor findings: if they represent real work, file them under the milestone-routing rule from Step 7 (inherit the source issue's milestone; deferral needs a rationale + `deferred:M<N>` label). If they don't represent real work, drop them entirely — do not leave findings in a "surface to user" limbo where they age untracked. Nit findings never block the PR on their own, but the filing itself is not optional when the finding is a real defect.
 
 ### Step 10 — Open the PR
 
@@ -318,8 +321,11 @@ gh pr create --base <base_branch> --title "<concise title from plan>" --body "$(
 <the staged plan, pasted from ~/.claude/plans/toloka-tolokaforge/issue-<N>-<short-name>.md — plans have no in-repo home, so the PR body is the plan's durable record>
 
 ## Discovered issues
-- Filed: #<n>, #<m>
-- Fixed in this PR: <one-line each>
+- **Filed as in-milestone follow-ups:** `#<n> [M<milestone>] — <one-line summary>`
+- **Deferred (rationale required):** `#<n> [deferred:M<milestone>] — <one-sentence reason it can't ship with this milestone>`
+- **Fixed in this PR:** <one-line each>
+
+If issue #<N> has no milestone, the "Filed" bullet drops the `[M<milestone>]` tag and issues land in the general backlog; the "Deferred" bullet does not apply outside an active-milestone run.
 
 ## Test plan
 - <bullets — what to verify post-merge>

--- a/.agents/skills/implement-milestone/SKILL.md
+++ b/.agents/skills/implement-milestone/SKILL.md
@@ -117,6 +117,21 @@ Everything in that skill applies except:
 
 Runs once the milestone has zero open issues (and every closed-as-completed issue has a `#<issue> →` line on the umbrella).
 
+0. **Follow-up milestone-routing check (guardrail).** Before touching the integration branch, verify every issue filed during this milestone run is either assigned to milestone M<N> or carries an explicit deferral. Run:
+
+    ```bash
+    # Every issue that references the integration branch or a per-issue branch in comments,
+    # OR was filed as a follow-up during the run, must satisfy one of:
+    #  (a) .milestone.number == <N>
+    #  (b) has label `deferred:M<N>` AND body contains a rationale line + cross-link to the source PR/milestone.
+    gh issue list --repo Toloka/tolokaforge --state all \
+        --search "created:>=<milestone-start-date> in:comments feat/<slug>" \
+        --json number,title,milestone,labels,body \
+        --jq '.[] | select(.milestone.number != <N> and ((.labels | map(.name) | index("deferred:M<N>")) | not))'
+    ```
+
+    Any row returned is a bookkeeping leak — an issue that surfaced during the milestone but never got routed. **Halt the consolidation** and surface the list to the user with the two options: fold each into M<N> (`gh issue edit <n> --milestone <N>`) or label as `deferred:M<N>` after adding a rationale + cross-link to its body. Only resume Step 4.1 once the query returns empty.
+
 1. **Rebase the integration branch on `main`.** `git checkout feat/<slug> && git fetch origin && git rebase origin/main`. Squash-merged per-issue commits stay individual on the integration branch — the rebase only shifts them onto the current `main` tip so the final PR presents as linear history. If the rebase conflicts, resolve inside `feat/<slug>` (never on `main`); push with `--force-with-lease` since only this skill writes to the integration branch. If conflicts are non-trivial, stop and ask.
 2. **Finalize the design journal.** Complete every stub in `~/.claude/plans/toloka-tolokaforge/milestone-<N>-integration.md`:
    - **TL;DR** — one paragraph naming the compatibility impact (or lack thereof) and ending with the roll-up of every `Closes #<n>` in the milestone.
@@ -144,12 +159,17 @@ The full template with placeholders and worked-example headings lives in `pr-tem
 
 ## Follow-ups and discovered work
 
-File everything you discover (bugs, improvements, deferred edge cases) as issues per the `writing-development-tickets` conventions — type label always, priority stated in the body. Then triage:
+**Every issue discovered during this milestone run is filed AGAINST milestone M<N> by default** — pass `milestone=<N>` on every `mcp__github__issue_write` and `gh issue create` call, and on retroactive `gh issue edit --milestone <N>` when a filed issue turned out to be in-scope. File per the `writing-development-tickets` conventions — type label always, priority stated in the body. Triage:
 
-- **High-priority and in-scope** → assign to the milestone and insert into the queue (implement this session).
-- **Low-priority or out-of-scope** → file, cross-link from the source issue/PR, leave for later. Note it in the final report and in the design journal's `## What's next` section.
+- **In-milestone** (the default): either absorb into the current session's queue (high-priority, small blast radius) or run as a fresh sub-ticket under the same milestone. Either way the issue carries `milestone=M<N>`.
+- **Deferred** (the only route out of the milestone) requires ALL of:
+  1. A one-sentence rationale explaining why this can't ship with milestone N — recorded in the source PR body's `## Discovered issues` section AND in the deferred issue's body.
+  2. A `deferred:M<N>` label on the deferred issue.
+  3. A cross-link naming the source PR + milestone in the deferred issue's body.
 
-Never let discovered work die in a PR comment or the conversation — if it isn't an issue, it didn't happen.
+A deferral without all three is a bookkeeping bug — the consolidation-PR guardrail (Step 4.0) will halt the run until it is corrected.
+
+Never let discovered work die in a PR comment or the conversation — if it isn't an issue, it didn't happen. Never file un-milestoned during an active-milestone run without recording a deferral rationale.
 
 ## Durable state — the session will outlive its context
 

--- a/.agents/skills/implement-milestone/pr-templates.md
+++ b/.agents/skills/implement-milestone/pr-templates.md
@@ -38,8 +38,11 @@ Discipline shared by both templates (modelled on [Toloka/tolokaforge#121](https:
 <the staged plan, pasted from ~/.claude/plans/toloka-tolokaforge/issue-<N>-<short-name>.md — plans have no in-repo home, so the PR body is the plan's durable record>
 
 ## Discovered issues
-- Filed: #<n>, #<m>
-- Fixed in this PR: <one-line each>
+- **Filed as in-milestone follow-ups:** `#<n> [M<milestone>] — <one-line summary>`
+- **Deferred (rationale required):** `#<n> [deferred:M<milestone>] — <one-sentence reason it can't ship with this milestone>`
+- **Fixed in this PR:** <one-line each>
+
+Rule: when issue #<N> has a milestone, every filed follow-up MUST carry the same milestone by default. Deferral requires the rationale above plus a `deferred:M<milestone>` label on the deferred issue AND a cross-link to this PR in its body. See `/executing-development-tickets` Step 7 for the mechanics. If issue #<N> has no milestone, drop the `[M<milestone>]` tag and the "Deferred" bullet doesn't apply.
 
 ## Test plan
 - <what to verify post-merge — one bullet per verification>
@@ -65,7 +68,9 @@ The consolidation PR body **is** the finalized running design journal (`~/.claud
 ## Impact on existing tasks — read this first
 - **Today (nothing changes):** <what continues to work exactly as before, and where the guard rails are>
 - **Near-term (opt-in):** <what users can adopt today if they want the new surface>
-- **Longer-term (planned):** <where this milestone points; forward links to follow-up issues>
+- **In-milestone follow-ups (still queued for this consolidation):** <bullets — `#<n> — one-line summary`; issues that carry `milestone=M<N>` and were absorbed into this run>
+- **Deferred (rationale + link):** <bullets — `#<n> — <one-sentence reason it can't ship with this milestone>`; each cross-links back here and carries the `deferred:M<N>` label. Empty section means nothing was deferred.>
+- **Longer-term (planned):** <where this milestone points beyond the deferred set; forward links to future-milestone issues>
 
 ## Design walkthrough
 <Two or three paragraphs framing the shape of the change. Enough that a reader who never saw the milestone can hold the picture. The Mermaid block below is the picture — not decorative.>
@@ -112,7 +117,10 @@ The stacked PRs, in the order that makes them make sense:
 - Deliberately skipped: <lane> — <reason, e.g. "integration-openai; no OPENAI_API_KEY set in this session — smoke covered by the equivalent Gemini lane">
 
 ## What's next
-<Two sentences of forward-looking scope. Follow-up issues filed during the milestone are linked here (`#<n>`, `#<m>`) with a one-line description each. If a follow-up milestone is already tracked, name it.>
+<Two sentences of forward-looking scope. In-milestone follow-ups and deferred issues are already listed under `Impact on existing tasks`; this section names the *next* horizon — the milestone or umbrella that picks up where this one stops. If a follow-up milestone is already tracked, name it.>
+
+## Deferrals
+<Complete list of every issue filed during this milestone that carries `deferred:M<N>` — one row per deferral: `#<n> — one-sentence rationale — <link to source PR>`. Empty if nothing was deferred. Consolidation-PR guardrail (Step 4.0) verifies each entry has a matching labeled issue with a cross-link.>
 ```
 
 **Anti-patterns to avoid:**

--- a/.claude/agents/system-architect-planner.md
+++ b/.claude/agents/system-architect-planner.md
@@ -23,7 +23,7 @@ If a user prompt or SendMessage asks you to "go ahead and implement", respond: "
 3. **Diagnose by running, not by reading.** Before proposing architecture, *observe* the current behaviour: dev MCP `run_tests` / `run_python`, `make docker-up` + `make docker-status` for the env services, a targeted `tolokaforge run --config examples/...` when the behaviour only shows end-to-end (needs LLM keys in `.env` — use sparingly, it costs real tokens). For bugfix plans, a test that reproduces the bug is Stage 1.
 4. **Lock behaviour with tests at the right tier.** `unit` for pure logic, `canonical` for contracts/snapshots (schema shapes, policy routing), `integration` for anything needing services or API keys. Plans test *desired behaviour* — tests that only exercise mocks or restate the implementation are forbidden in your plans (AGENTS.md: "mocks hide problems, test real behavior").
 5. **No compromise.** Where the choice is "fast patch vs right architecture", the plan picks the architecture. Do not fold a quick patch into the plan as a temporary step. If urgency overrides architecture, that is a separate emergency plan with an explicit follow-up issue.
-6. **Surface what you discover.** While studying, you will see other problems. For each: decide *fix in this PR* (cheap, in the neighbourhood) or *file a GitHub issue via the GitHub MCP* (anything else). Both decisions go in the plan's "Discovered issues" section. Never bury what you saw.
+6. **Surface what you discover, and fold it into the same milestone.** While studying, you will see other problems. For each: decide *fix in this PR* (cheap, in the neighbourhood) or *file a GitHub issue via the GitHub MCP* (anything else). **When the source issue belongs to a milestone, every filed follow-up MUST be assigned to that same milestone** — pass `milestone=<N>` to `mcp__github__issue_write`. Deferral out of the milestone requires a one-sentence written rationale in the plan's "Discovered issues" section explaining why it can't ship with the milestone. Never bury what you saw; never file un-milestoned during an active-milestone run without a recorded rationale.
 7. **Self-explanatory code, no history lessons.** Your plan never instructs implementers to write "added in stage 2" / "per AGENTS.md Rule N" / "stage 3 will derive this" comments. Decision rationale lives in the plan and PR description. See the code-review skill §7a for the comment patterns the reviewer will reject.
 8. **Documentation is always current — only actual state.** Source-of-truth docs (`AGENTS.md`, `docs/*.md`, `README.md`, `tests/README.md`, `scripts/README.md`) describe the system *as it is right now* (AGENTS.md Core Rule 8). No "previously X, now Y", no "before the refactor", no migration history. When a stage changes behaviour, the doc reads as if the new state is the only state — and legacy mentions elsewhere are deleted in the same commit (`rg <old-name>` is mandatory). Plan files are journals, not substitutes for current docs.
 9. **AGENTS.md is binding.** Read root `AGENTS.md` in full before planning. A plan that violates one of its invariants — raw secret access outside `SecretManager`, task-specific logic in the harness, Python branches on model name instead of the preset registry / `ModelCapabilities` policy slots, the wrong type-system choice for a contract, touching `contrib/`, skipping capability tests for a model PR — is wrong even if it is the shortest route. Project rules win against your defaults.
@@ -73,7 +73,8 @@ Branch: feat|fix|chore/<short-name>
 
 ## Discovered issues
 - **Fix in this PR:** <bullets — cheap, in the neighbourhood>
-- **Filed as issues:** <bullets with issue numbers created via GitHub MCP>
+- **Filed as in-milestone follow-ups:** <bullets: `#N [M<milestone> in-scope] — one-line summary`>
+- **Deferred (rationale required):** <bullets: `#N [deferred:M<milestone>] — one-sentence reason it can't ship with this milestone`>
 
 ## Risks / open questions
 <bullets — surface, don't bury>
@@ -87,7 +88,11 @@ Branch: feat|fix|chore/<short-name>
 - Doc updates are named per stage, not collected at the end. The instruction must be "rewrite section X so it reads as if the new state is the only state" — never "add a note that this changed".
 - `_legacy_*` names and "remove later" stages for *internal* code are forbidden — if a deletion is needed, it gets its own stage.
 
-File "Discovered issues" with the GitHub MCP (`mcp__github__issue_write`, `owner=Toloka`, `repo=tolokaforge`) *while* drafting — by the time you return to main, the plan's "Filed as issues" bullets should already reference real issue numbers. This is part of planning, not execution.
+File "Discovered issues" with the GitHub MCP (`mcp__github__issue_write`, `owner=Toloka`, `repo=tolokaforge`) *while* drafting — by the time you return to main, the plan's "Filed" and "Deferred" bullets should already reference real issue numbers.
+
+**Milestone routing (required):** before filing, read the source issue's `.milestone.number` via `gh issue view <N> --json milestone`. If the source has a milestone: pass `milestone=<that number>` on every `mcp__github__issue_write` call. If the source has no milestone: file to backlog. **Never file un-milestoned during an active-milestone run.** For a deliberate deferral, omit `milestone` AND (a) record the one-sentence rationale in the plan's "Deferred" bullet, (b) add label `deferred:M<N>` to the deferred issue, (c) cross-link the source PR + milestone in the deferred issue's body.
+
+This is part of planning, not execution.
 
 ## Phase 3: Return to main
 


### PR DESCRIPTION
## Summary

Invert the default routing for follow-up issues surfaced during `/executing-development-tickets` and `/implement-milestone`. Previously the planner and main filed `mcp__github__issue_write` calls without a `milestone` field — every follow-up landed unassigned in the general backlog and aged out of sight. Now: **when the source issue belongs to a milestone, every filed follow-up inherits that milestone unless the operator records a written deferral rationale.**

## Why

Observed across the last 3 backlog-hygiene sessions: the skills produce quality code but generate new issues faster than they close. Milestones ship, but their "discovered issues" tail lives only in the design journal's `## What's next` section — invisible outside a specific PR body — so the operator loses sight of them and they age into the P3-stale bucket.

Audit of `.claude/agents/*` and `.claude/skills/*` confirmed the root cause:

- `system-architect-planner.md:26,90` — `mcp__github__issue_write` calls with no `milestone` field. Every filed issue lands in the general backlog.
- `executing-development-tickets/SKILL.md:240,300` — same at Step 7; nit/minor findings escape to a "surface to user" limbo where they age untracked.
- `implement-milestone/SKILL.md:147-152` — the ONLY same-milestone-fold-in instruction, but opt-in. Templates and reports around it reinforce deferred-by-default framing.
- `pr-templates.md:40-42, 68, 114-115` — Discovered-issues slot had no priority or milestone annotation; consolidation "Longer-term (planned)" assumed deferred.

## Changes

- **`.claude/agents/system-architect-planner.md`** — Rule 6 rewritten to require milestone inheritance during a milestoned run; Discovered-issues template gains "In-milestone" vs "Deferred" bullets; Phase 2 filing instruction explicitly requires `milestone=<N>` on `mcp__github__issue_write` calls plus the three-part deferral gate.
- **`.claude/skills/executing-development-tickets/SKILL.md`** — Step 3a (architect briefing), Step 7 (main files reviewer findings), the nit/minor branch, and the Step 10 PR body template all updated to inherit-by-default with the same deferral gate.
- **`.claude/skills/implement-milestone/SKILL.md`** — §Follow-ups inverted (in-milestone by default; deferral requires rationale + `deferred:M<N>` label + cross-link); new **Step 4.0 consolidation-PR guardrail** halts the run if any follow-up is un-milestoned without the deferral trio.
- **`.claude/skills/implement-milestone/pr-templates.md`** — per-issue Discovered-issues section gets in-milestone/deferred columns; consolidation body's "Impact on existing tasks" splits into "In-milestone follow-ups" + "Deferred (rationale + link)"; new `## Deferrals` block for the audit trail.

## Deferral is the only route out

Every filing site now says the same thing:

- **In-milestone (default)** — pass `milestone=<N>` on `mcp__github__issue_write` / `gh issue create`.
- **Deferred (opt-out)** requires all of:
  1. One-sentence rationale in the source PR body's `## Discovered issues` section.
  2. `deferred:M<N>` label on the deferred issue.
  3. Cross-link naming the source PR + milestone in the deferred issue's body.

The **Step 4.0 guardrail** at consolidation time is the enforcement point — it halts the run if any issue filed during the milestone lacks either the milestone assignment or the full deferral trio.

## Related research (not adopted here)

Researched GitHub's **stacked pull requests** (public preview since 2026-07-30) as an alternative execution shape. Verdict: **adopt-with-caveats, but not now.** Squash-merge behaviour isn't documented, merge-queue support is still rolling out, and our integration-branch + consolidation-PR pattern already gives the design-journal seam that stacks would eliminate. Revisit at GA. This PR does not change the milestone execution shape — only the issue-routing rule that operates within it.

## Test plan

- [ ] Static re-audit: `grep -n 'mcp__github__issue_write\|milestone=' .claude/agents/system-architect-planner.md .agents/skills/*/SKILL.md .agents/skills/*/pr-templates.md` shows every filing site references milestone inheritance + the deferral gate.
- [ ] Dry-run next `/executing-development-tickets` invocation on a milestoned issue and confirm the planner's `mcp__github__issue_write` calls carry the milestone number.
- [ ] Next `/implement-milestone` consolidation-PR run exercises Step 4.0; if any un-milestoned follow-up exists, the run halts before opening the PR.
- [ ] Weekly-triage picks up `deferred:M<N>`-labelled issues so deferrals stay visible without hunting through PR bodies.

## Out of scope

- **Re-milestoning historical backlog.** The 400+ currently-open unassigned issues predate this change; the weekly-triage + stale-audit pattern handles them.
- **Auto-detecting milestone from branch name alone.** Rule reads the source issue's `.milestone.number`, not the branch — branch names are advisory.
- **GH-side workflow to reject un-milestoned issue creation.** Enforcement stays at the skill/PR-review layer; PR #1282's intake templates handle the general case.