### PR TITLE
feat(adapter): task-yaml override for per-tool output_max_chars

### DIFF
--- a/docs/GRPC_PROTOCOL.md
+++ b/docs/GRPC_PROTOCOL.md
@@ -709,10 +709,13 @@ nothing is the deliberately non-scoring shape and grades `(1.0, True)`.
 #### ToolSchema.output_max_chars
 
 Each `ToolSchema` the runner returns in `RegisterTrialResponse.tool_schemas` may
-carry an optional `output_max_chars: int` — the per-tool cap the runner lifts
-from `ToolPolicy.output_max_chars` for the corresponding tool. The harness reads
-it back (via `HasField`) and threads it into the engine loop, where the loop
-composes it with the per-model
+carry an optional `output_max_chars: int` — the per-tool cap on the corresponding
+tool's `role=tool` message content. The native adapter composes two inputs into
+the emitted value (`min` of whichever are set): `ToolPolicy.output_max_chars`
+(the tool-declared bound) and the task-yaml override at
+`tools.<actor>.<tool_name>.output_max_chars`. The harness reads the value back
+(via `HasField`) and threads it into the engine loop, where the loop composes
+it with the per-model
 [`ModelCapabilities.tool_output_max_chars`](LLM_LAYER.md#tool-output-truncation)
 as `min(tool_cap, capability_cap)`: the tighter set cap wins per call. Absent
 the field the harness reads `None` and defers to the per-model cap alone. The

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -2020,30 +2020,40 @@ land alongside the run data that justified the chosen watermark.
 
 ### Tool-output truncation
 
-The loop layer caps the `content` a `role=tool` message carries into the
-next prompt along two axes and picks the tighter one per call:
+The `content` a `role=tool` message carries into the next prompt is capped
+along three axes and the tighter set candidate wins. Ordered narrowest-first
+by scope:
 
-- `ModelCapabilities.tool_output_max_chars: int | None` is the per-model
-  backstop; a preset that names the key applies its cap uniformly to every
-  trial that runs on that model.
+- `tools.<actor>.<tool_name>.output_max_chars: int | None` is the task-yaml
+  override — a pack author's per-tool cap on the tool as used in this pack,
+  tighter than the tool's own declared bound. Reserved sibling to the
+  block's per-tool init kwargs; positive int, else the loader rejects it at
+  authoring time.
 - `ToolPolicy.output_max_chars: int | None` is the per-tool declared bound
   a tool sets on its own output — a status poll that always returns ≤512
   chars declares that shape once at registration and every loop composes it
   correctly.
+- `ModelCapabilities.tool_output_max_chars: int | None` is the per-model
+  backstop; a preset that names the key applies its cap uniformly to every
+  trial that runs on that model.
 
-`ToolCallingLoop._cap_tool_message_content` computes
-`effective = min(tool_cap, capability_cap)` when both are set, uses
-whichever is set alone otherwise, and threads the content verbatim when
-neither is set. Middle-elision uses `keep_head_and_tail` from
+The composition runs at two sites, each using the same shape (`min` of the
+set candidates, `None` when none is set). The adapter site
+(`native._actor_tool_schemas`) folds the task-yaml override and the
+tool-declared bound into the emitted `ToolSchema.output_max_chars`. The
+loop site (`ToolCallingLoop._cap_tool_message_content`) folds that emitted
+value with the per-model backstop into the per-call effective cap.
+
+Middle-elision uses `keep_head_and_tail` from
 [`tolokaforge/core/tool_output_truncation.py`](../tolokaforge/core/tool_output_truncation.py:1)
 so accumulated context stays predictable across trials whose tools return
 unbounded strings (browser tool DOM dumps, database result sets, RAG hit
 lists, task-pack MCP tool output). Reasoning-heavy models are the norm; a
 first-class engine policy for bounding tool-output size that lands on the
 message history is a general improvement rather than a per-model
-workaround. Absent both a preset key and a per-tool declaration, tool
-messages pass through verbatim — the baseline for presets that do not
-name the key on tools that do not declare a cap.
+workaround. Absent all three axes, tool messages pass through verbatim —
+the baseline for presets that do not name the key on tools that do not
+declare a cap in a pack that does not override it.
 
 The cap sits **below** the trial's recorder and the grader. The recorder
 call inside `_execute_tool_calls` reads the full text through
@@ -2087,12 +2097,13 @@ search, MCP tool output) rely on the loop caps alone.
 wired from
 [`ToolRegistry.output_max_chars_by_tool`](../tolokaforge/tools/registry.py:1)
 by the callers that construct the loop over a live registry. Task-pack
-tools reach the harness through the runner: the runner emits each tool's
-`ToolPolicy.output_max_chars` on the wire as
+tools reach the harness through the runner: the native adapter composes
+`ToolPolicy.output_max_chars` with the task-yaml override into
 [`ToolSchema.output_max_chars`](GRPC_PROTOCOL.md#toolschemaoutput_max_chars),
-the harness reads it back via `HasField`, the conductor lifts the set-only
-subset into a per-trial map on `_TrialSetup`, and the map is threaded into
-`TrialRunner.__init__` and on into the loop. Preset routing is pinned by
+the runner emits it on the wire, the harness reads it back via `HasField`,
+the conductor lifts the set-only subset into a per-trial map on
+`_TrialSetup`, and the map is threaded into `TrialRunner.__init__` and on
+into the loop. Preset routing is pinned by
 [`tests/canonical/test_tool_output_max_chars_preset_routing.py`](../tests/canonical/test_tool_output_max_chars_preset_routing.py);
 the loop-layer behaviour and the helper contract are pinned by
 [`tests/unit/test_tool_calling_loop.py`](../tests/unit/test_tool_calling_loop.py)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -360,6 +360,8 @@ tools:
 
 The `mobile` tool uses a phone-sized viewport (412x915) and only exposes tap, type, scroll, and gesture actions — no URL navigation, search, or browser-specific actions. See [BROWSER_TOOLS.md](BROWSER_TOOLS.md) for full details.
 
+Any tool block also accepts an `output_max_chars: int` sibling that caps the `role=tool` message content the loop appends for that tool in this pack. It composes with the tool's declared bound and the per-model backstop; the tighter set candidate wins. See [`LLM_LAYER.md § Tool-output truncation`](LLM_LAYER.md#tool-output-truncation) for the composition rule.
+
 ## Mobile App Fixtures
 
 Mobile app tasks in `tasks/mobile/` share a common mock data layer and theming approach:

--- a/docs/TASK_DESCRIPTION_SCHEMA.md
+++ b/docs/TASK_DESCRIPTION_SCHEMA.md
@@ -116,9 +116,12 @@ harness for the tool's `role=tool` message content. The engine loop composes it
 with the per-model
 [`ModelCapabilities.tool_output_max_chars`](LLM_LAYER.md#tool-output-truncation)
 backstop as `min(tool_cap, capability_cap)`: the tighter set cap wins per call.
-Lifted from `ToolPolicy.output_max_chars` at the runner. `None` (the default)
-defers to the per-model cap; a tool that declares no cap and runs under a preset
-that declares no cap passes its message content through verbatim.
+The native adapter composes two inputs into the value it emits:
+`ToolPolicy.output_max_chars` (the tool-declared bound) and the task-yaml
+override at `tools.<actor>.<tool_name>.output_max_chars`, as `min` of whichever
+are set. `None` (the default) defers to the per-model cap; a tool that declares
+no cap in a pack that overrides no cap, run under a preset that declares no cap,
+passes its message content through verbatim.
 
 ```python
 # =============================================================================

--- a/tests/unit/test_native_adapter_builtin_dispatch.py
+++ b/tests/unit/test_native_adapter_builtin_dispatch.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tolokaforge.adapters._task_loader import _builtin_tool_schemas
+from tolokaforge.adapters._task_loader import _builtin_tool_schemas, load_task_yaml
 from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.runner.models import InvocationStyle
 
@@ -355,3 +355,155 @@ def test_native_adapter_emits_output_max_chars_on_the_wire_toolschema(monkeypatc
 
     stub = next(t for t in td.agent_tools if t.name == "stub_capped")
     assert stub.output_max_chars == 512
+
+
+# ---------------------------------------------------------------------------
+# tools.<actor>.<tool_name>.output_max_chars — task-yaml override
+# ---------------------------------------------------------------------------
+
+
+class _StubUncappedTool:
+    """Stub builtin whose ``policy`` leaves ``output_max_chars`` at ``None``."""
+
+    def __init__(self) -> None:
+        from tolokaforge.tools.registry import ToolPolicy
+
+        self.policy = ToolPolicy()
+
+    def get_schema(self) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": "stub_uncapped",
+                "description": "An uncapped stub tool.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+
+def _task_dir_with_stub_block(tmp_path: Path, tool_name: str, block: dict) -> Path:
+    """Write a minimal one-tool task.yaml under ``tmp_path`` and return its parent."""
+    task_dir = tmp_path / "override_task"
+    task_dir.mkdir()
+    (task_dir / "task.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "task_id": "override_task",
+                "name": "override task",
+                "description": "one builtin, one block",
+                "category": "compute",
+                "max_turns": 2,
+                "interaction_mode": "conversational",
+                "initial_user_message": "poll",
+                "initial_state": {},
+                "tools": {
+                    "agent": {"enabled": [tool_name], tool_name: block},
+                    "user": {"enabled": []},
+                },
+                "actors": {"user": {"mode": "llm"}},
+            }
+        )
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    ("task_yaml_cap", "tool_name", "expected_emitted_cap"),
+    [
+        # (task_yaml_cap, tool_stub_name, expected emitted ToolSchema.output_max_chars)
+        (None, "stub_uncapped", None),  # neither axis set
+        (None, "stub_capped", 512),  # only tool-declared
+        (512, "stub_uncapped", 512),  # only task-yaml
+        (256, "stub_capped", 256),  # task-yaml tighter
+        (1024, "stub_capped", 512),  # tool-declared tighter
+        (512, "stub_capped", 512),  # equal, stable
+    ],
+    ids=[
+        "neither_set",
+        "only_tool_declared",
+        "only_task_yaml",
+        "task_yaml_tighter",
+        "tool_declared_tighter",
+        "equal",
+    ],
+)
+def test_native_adapter_composes_task_yaml_and_tool_declared_output_max_chars(
+    monkeypatch,
+    tmp_path: Path,
+    task_yaml_cap: int | None,
+    tool_name: str,
+    expected_emitted_cap: int | None,
+):
+    """The emitted ``ToolSchema.output_max_chars`` is
+    ``min(task_yaml_cap, tool_declared_cap)`` when both are set, whichever is
+    set alone otherwise, ``None`` when neither is set. Locks the composition
+    at ``native._actor_tool_schemas``.
+    """
+    from tolokaforge.tools.builtin import registry as builtin_registry
+
+    classes = {"stub_capped": _StubCappedTool, "stub_uncapped": _StubUncappedTool}
+    monkeypatch.setattr(builtin_registry, "is_builtin", lambda name: name in classes)
+    monkeypatch.setattr(builtin_registry, "get_class", lambda name: classes[name])
+
+    block: dict = {}
+    if task_yaml_cap is not None:
+        block["output_max_chars"] = task_yaml_cap
+    base_dir = _task_dir_with_stub_block(tmp_path, tool_name, block)
+    adapter = NativeAdapter({"tasks_glob": "*/task.yaml", "base_dir": str(base_dir)})
+    td = adapter.to_task_description("override_task")
+
+    tool = next(t for t in td.agent_tools if t.name == tool_name)
+    assert tool.output_max_chars == expected_emitted_cap
+
+
+def test_tool_configs_strips_output_max_chars_and_keeps_other_kwargs(tmp_path: Path):
+    """``tool_configs`` returns a mapping the runner can splat verbatim: the
+    reserved ``output_max_chars`` key never appears, and other kwargs pass
+    through unchanged.
+    """
+    from tolokaforge.adapters._task_loader import ToolActor, tool_configs
+
+    base_dir = _task_dir_with_stub_block(
+        tmp_path, "stub", {"other_kwarg": "x", "output_max_chars": 512}
+    )
+    task, _ = load_task_yaml(base_dir / "override_task" / "task.yaml")
+
+    configs = tool_configs(task, ToolActor.AGENT)
+
+    assert configs == {"stub": {"other_kwarg": "x"}}
+    assert "output_max_chars" not in configs.get("stub", {})
+
+
+def test_tool_configs_drops_entry_when_block_names_only_reserved_keys(tmp_path: Path):
+    """A block that declares nothing but reserved keys yields no entry in
+    :func:`tool_configs` — the runner receives no unknown kwargs to reject.
+    """
+    from tolokaforge.adapters._task_loader import ToolActor, tool_configs
+
+    base_dir = _task_dir_with_stub_block(tmp_path, "stub", {"output_max_chars": 512})
+    task, _ = load_task_yaml(base_dir / "override_task" / "task.yaml")
+
+    configs = tool_configs(task, ToolActor.AGENT)
+
+    assert "output_max_chars" not in configs.get("stub", {})
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [0, -1, 3.14, "512", True],
+    ids=["zero", "negative", "float", "string", "bool_true"],
+)
+def test_tool_output_max_chars_override_rejects_non_positive_int(tmp_path: Path, bad_value):
+    """A non-int, non-positive, or bool ``output_max_chars`` fails loud at
+    authoring time rather than reaching the wire as a nonsense cap.
+    """
+    from tolokaforge.adapters._task_loader import (
+        ToolActor,
+        tool_output_max_chars_overrides,
+    )
+
+    base_dir = _task_dir_with_stub_block(tmp_path, "stub", {"output_max_chars": bad_value})
+    task, _ = load_task_yaml(base_dir / "override_task" / "task.yaml")
+
+    with pytest.raises(ValueError, match=r"tools\.agent\.stub\.output_max_chars"):
+        tool_output_max_chars_overrides(task, ToolActor.AGENT)

--- a/tests/unit/test_native_adapter_builtin_dispatch.py
+++ b/tests/unit/test_native_adapter_builtin_dispatch.py
@@ -456,6 +456,35 @@ def test_native_adapter_composes_task_yaml_and_tool_declared_output_max_chars(
     assert tool.output_max_chars == expected_emitted_cap
 
 
+def test_search_kb_task_yaml_override_composes_with_the_canonical_schema(tmp_path: Path):
+    """``search_kb`` takes a different construction path
+    (``create_search_kb_schema()`` bypasses ``_builtin_tool_schemas``), but
+    the task-yaml override still composes with the schema's own
+    ``output_max_chars`` under the same tighter-wins rule the generic
+    branch applies. Locks the third-axis contract for the special-cased
+    tool so a future refactor cannot silently drop the override there.
+    """
+    base_dir = _task_dir_with_stub_block(tmp_path, "search_kb", {"output_max_chars": 256})
+    adapter = NativeAdapter({"tasks_glob": "*/task.yaml", "base_dir": str(base_dir)})
+    td = adapter.to_task_description("override_task")
+
+    tool = next(t for t in td.agent_tools if t.name == "search_kb")
+    assert tool.output_max_chars == 256
+
+
+def test_search_kb_without_override_preserves_canonical_schema(tmp_path: Path):
+    """Absent an override, ``search_kb`` emits whatever ``create_search_kb_schema``
+    declares — today ``None``. Pins the neither-axis-set row for the special
+    branch so a canonical-schema change lights up here first.
+    """
+    base_dir = _task_dir_with_stub_block(tmp_path, "search_kb", {})
+    adapter = NativeAdapter({"tasks_glob": "*/task.yaml", "base_dir": str(base_dir)})
+    td = adapter.to_task_description("override_task")
+
+    tool = next(t for t in td.agent_tools if t.name == "search_kb")
+    assert tool.output_max_chars is None
+
+
 def test_tool_configs_strips_output_max_chars_and_keeps_other_kwargs(tmp_path: Path):
     """``tool_configs`` returns a mapping the runner can splat verbatim: the
     reserved ``output_max_chars`` key never appears, and other kwargs pass

--- a/tests/unit/test_native_adapter_builtin_dispatch.py
+++ b/tests/unit/test_native_adapter_builtin_dispatch.py
@@ -490,8 +490,8 @@ def test_tool_configs_drops_entry_when_block_names_only_reserved_keys(tmp_path: 
 
 @pytest.mark.parametrize(
     "bad_value",
-    [0, -1, 3.14, "512", True],
-    ids=["zero", "negative", "float", "string", "bool_true"],
+    [0, -1, 3.14, "512", True, False],
+    ids=["zero", "negative", "float", "string", "bool_true", "bool_false"],
 )
 def test_tool_output_max_chars_override_rejects_non_positive_int(tmp_path: Path, bad_value):
     """A non-int, non-positive, or bool ``output_max_chars`` fails loud at

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -696,13 +696,29 @@ def declared_tool_names(task: Any) -> frozenset[str]:
     return frozenset().union(*(enabled_tool_names(task, actor) for actor in ToolActor))
 
 
+TOOL_BLOCK_RESERVED_KEYS: frozenset[str] = frozenset({"output_max_chars"})
+"""Keys the harness reads from a ``tools.<actor>.<tool_name>`` block for its own
+composition, not as tool ``__init__`` kwargs.
+
+The runner's builtin factory splats ``ToolSchema.tool_config`` into the tool
+class and refuses unknown keys, so a reserved key that reached the runner would
+raise ``ToolConfigurationError`` at trial registration. Stripping in
+:func:`tool_configs` keeps that seam clean; each key has its own lifter
+(:func:`tool_output_max_chars_overrides` for ``output_max_chars``) that returns
+the harness-side value."""
+
+
 def tool_configs(task: TaskConfig, actor: ToolActor) -> dict[str, dict]:
     """Per-tool init kwargs lifted from the ``tools.<actor>.<name>`` blocks.
 
-    Only enabled tools are read. The kwargs reach the runner via
-    ``ToolSchema.tool_config`` and drive the builtin instantiation whose schema
-    depends on them (``MobileTool(apps={…})`` populates
-    ``actions[].app_name.enum``).
+    Only enabled tools are read. Keys in :data:`TOOL_BLOCK_RESERVED_KEYS` are
+    stripped — they are harness-side knobs (read by dedicated lifters such as
+    :func:`tool_output_max_chars_overrides`), not tool constructor kwargs. A
+    block that names only reserved keys yields no entry in the returned mapping.
+
+    The kwargs reach the runner via ``ToolSchema.tool_config`` and drive the
+    builtin instantiation whose schema depends on them (``MobileTool(apps={…})``
+    populates ``actions[].app_name.enum``).
 
     Raises:
         ValueError: If a block is present but is not a mapping — an author typo
@@ -720,8 +736,43 @@ def tool_configs(task: TaskConfig, actor: ToolActor) -> dict[str, dict]:
                 f"tools.{actor.value}.{tool_name} must be a mapping of init kwargs "
                 f"(got {type(raw).__name__}={raw!r}) in task {task.task_id!r}"
             )
-        configs[tool_name] = dict(raw)
+        kwargs = {k: v for k, v in raw.items() if k not in TOOL_BLOCK_RESERVED_KEYS}
+        if kwargs:
+            configs[tool_name] = kwargs
     return configs
+
+
+def tool_output_max_chars_overrides(task: TaskConfig, actor: ToolActor) -> dict[str, int]:
+    """Per-tool ``output_max_chars`` overrides declared on ``tools.<actor>.<name>``.
+
+    Returns ``{tool_name: cap}`` for every enabled tool whose block names a
+    positive-int ``output_max_chars`` sibling. The value composes with the
+    tool's own :attr:`~tolokaforge.tools.registry.ToolPolicy.output_max_chars`
+    (adapter-side ``min``) into the emitted ``ToolSchema.output_max_chars``; the
+    loop then composes that with the per-model backstop. An absent key or
+    ``None`` value leaves the tool out of the returned mapping.
+
+    Raises:
+        ValueError: If ``output_max_chars`` is present with a non-int or a
+            non-positive value. Task YAML is authoring surface, so a typo
+            fails loud rather than reaching the wire as a nonsense cap.
+    """
+    block = actor_tool_block(task, actor)
+    overrides: dict[str, int] = {}
+    for tool_name in block.get("enabled", []):
+        raw = block.get(tool_name)
+        if not isinstance(raw, dict):
+            continue
+        value = raw.get("output_max_chars")
+        if value is None:
+            continue
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ValueError(
+                f"tools.{actor.value}.{tool_name}.output_max_chars must be a positive int "
+                f"(got {type(value).__name__}={value!r}) in task {task.task_id!r}"
+            )
+        overrides[tool_name] = value
+    return overrides
 
 
 def resolve_tool_schemas(

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -21,6 +21,7 @@ from tolokaforge.adapters._task_loader import (
     resolve_tool_schemas,
     seeded_tables_from_task,
     tool_configs,
+    tool_output_max_chars_overrides,
 )
 from tolokaforge.adapters.base import (
     AdapterEnvironment,
@@ -197,6 +198,7 @@ def _actor_tool_schemas(task: TaskConfig, task_dir: Path, actor: ToolActor) -> l
         raise RuntimeError(f"MCP server script not found: {task_dir / mcp_server_ref}")
 
     configs = tool_configs(task, actor)
+    overrides = tool_output_max_chars_overrides(task, actor)
     rich_schemas = resolve_tool_schemas(task, task_dir, actor, allow_subprocess=True)
 
     schemas: list[ToolSchema] = []
@@ -223,6 +225,10 @@ def _actor_tool_schemas(task: TaskConfig, task_dir: Path, actor: ToolActor) -> l
             if mcp_server_ref
             else None
         )
+        cap_candidates = [
+            c for c in (rich.get("output_max_chars"), overrides.get(tool_name)) if c is not None
+        ]
+        emitted_cap = min(cap_candidates) if cap_candidates else None
         schemas.append(
             ToolSchema(
                 name=tool_name,
@@ -234,7 +240,7 @@ def _actor_tool_schemas(task: TaskConfig, task_dir: Path, actor: ToolActor) -> l
                 timeout_s=30.0,
                 source=source,
                 tool_config=configs.get(tool_name, {}),
-                output_max_chars=rich.get("output_max_chars"),
+                output_max_chars=emitted_cap,
             )
         )
     return schemas

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -207,7 +207,15 @@ def _actor_tool_schemas(task: TaskConfig, task_dir: Path, actor: ToolActor) -> l
             # The runner reconstructs search_kb as a RAGSearchToolWrapper
             # (source-less, RAG dispatch). Carry the canonical schema so
             # the LLM sees the real {query, top_k, alpha} parameters.
-            schemas.append(create_search_kb_schema())
+            # The task-yaml override composes with the schema's existing
+            # ``output_max_chars`` under the same tighter-wins rule the
+            # generic branch below applies to every other tool.
+            base = create_search_kb_schema()
+            cap_candidates = [
+                c for c in (base.output_max_chars, overrides.get(tool_name)) if c is not None
+            ]
+            emitted_cap = min(cap_candidates) if cap_candidates else None
+            schemas.append(base.model_copy(update={"output_max_chars": emitted_cap}))
             continue
         if mcp_server_ref is None and not builtin_registry.is_builtin(tool_name):
             raise NativeAdapterMisconfigurationError(

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -163,12 +163,15 @@ class ToolSchema(BaseModel):
     output_max_chars: int | None = None
     """Per-tool cap on the ``role=tool`` message content the engine loop appends.
 
-    Lifted from :attr:`tolokaforge.tools.registry.ToolPolicy.output_max_chars` by
-    the runner when it emits the tool's schema, and read back by the harness so
-    the engine loop composes it with the per-model
+    The adapter composes two inputs into this value —
+    :attr:`tolokaforge.tools.registry.ToolPolicy.output_max_chars` (the
+    tool-declared bound) and the task-yaml override
+    ``tools.<actor>.<tool_name>.output_max_chars`` — as ``min`` of whichever
+    are set. The runner returns the composed value to the harness, and the
+    engine loop composes it in turn with the per-model
     :attr:`~tolokaforge.core.model_capabilities.ModelCapabilities.tool_output_max_chars`
     as ``min(tool_cap, capability_cap)``. ``None`` defers to the per-model cap;
-    a task pack that neither declares a per-tool cap nor runs a preset naming
+    a tool with no declared bound, no task-yaml override, and no preset naming
     the per-model cap passes the tool message through verbatim.
     """
 

--- a/tolokaforge/runner/runner.proto
+++ b/tolokaforge/runner/runner.proto
@@ -118,7 +118,7 @@ message ToolSchema {
   // The engine loop composes the result in turn with the per-model
   // ModelCapabilities.tool_output_max_chars as min(tool_cap, capability_cap):
   // the tighter set cap wins per call. Optional (proto3): a runner predating
-  // this field, a tool whose policy does not name a cap in a pack with no
+  // this field, or a tool whose policy does not name a cap in a pack with no
   // override, sends nothing and the harness reads that as no per-tool cap.
   optional int32 output_max_chars = 6;
 }

--- a/tolokaforge/runner/runner.proto
+++ b/tolokaforge/runner/runner.proto
@@ -111,12 +111,15 @@ message ToolSchema {
   // Timeout override for this specific tool
   double timeout_s = 5;
 
-  // Per-tool cap on the role=tool message content the engine loop appends,
-  // lifted from ToolPolicy.output_max_chars. Composed with the per-model
+  // Per-tool cap on the role=tool message content the engine loop appends.
+  // The native adapter composes two inputs into the emitted value (min of
+  // whichever are set): ToolPolicy.output_max_chars (the tool-declared bound)
+  // and the task-yaml override at tools.<actor>.<tool_name>.output_max_chars.
+  // The engine loop composes the result in turn with the per-model
   // ModelCapabilities.tool_output_max_chars as min(tool_cap, capability_cap):
   // the tighter set cap wins per call. Optional (proto3): a runner predating
-  // this field, or a tool whose policy does not name a cap, sends nothing and
-  // the harness reads that as no per-tool cap.
+  // this field, a tool whose policy does not name a cap in a pack with no
+  // override, sends nothing and the harness reads that as no per-tool cap.
   optional int32 output_max_chars = 6;
 }
 


### PR DESCRIPTION
## Summary

Adds a third axis to the tool-output cap composition: per-task-YAML override at `tools.<actor>.<tool_name>.output_max_chars`. The narrower of the task-yaml cap and the tool-declared `ToolPolicy.output_max_chars` wins per emitted `ToolSchema.output_max_chars`; the loop-side composition with the per-model cap is unchanged. Fixes a fail-loud gap where the ticket's own authoring shape used to raise `ToolConfigurationError` at trial registration.

Closes #1554.

## Design choices

| Decision | Rationale |
|---|---|
| Authoring surface `tools.<actor>.<tool_name>.output_max_chars` (sibling to init kwargs) | Matches the ticket's proposed shape; single YAML location per tool. Reserved-key seam mirrors `mcp_server` precedent already in `_task_loader.py`. |
| Adapter-side `min(task_yaml_cap, tool_declared_cap)` at emit site | Composition happens once at `native.py::_actor_tool_schemas` before the emitted `ToolSchema` crosses the wire. Loop-side composition with `LoopConfig.tool_output_max_chars` is unchanged. Empty-list guard is load-bearing (both `None` → no cap). |
| MCP-served tools compose naturally | Single emit site in `native.py:237`. `rich.get("output_max_chars")` is `None` for MCP today; the override still works via the `min`-of-set-candidates rule. |
| Reject `output_max_chars <= 0` at authoring | Fail-loud on authoring surface; `head+tail=0` is almost certainly a typo. Also rejects `bool`, non-int, and stringified ints. |
| `tool_configs()` strips the reserved key unconditionally | Prevents `tool_factory.py:861`'s unknown-kwargs raise from firing on the reserved key. A block naming only reserved keys yields no entry in the returned mapping. |

## Test plan
- [x] Unit: `test_native_adapter_composes_task_yaml_and_tool_declared_output_max_chars` — 6-row parametrised precedence table.
- [x] Unit: `test_tool_configs_strips_output_max_chars_and_keeps_other_kwargs` — positive case.
- [x] Unit: `test_tool_configs_drops_entry_when_block_names_only_reserved_keys` — kwargs-isolation.
- [x] Unit: `test_tool_output_max_chars_override_rejects_non_positive_int` — parametrised over `[0, -1, 3.14, "512", True]`.
- [x] Canonical: `test_native_adapter_canon.py` — snapshot invariants hold.
- [x] E2E probe: `read_file` with `output_max_chars: 512` in a task YAML now flows to the emitted `ToolSchema.output_max_chars=512` instead of raising `ToolConfigurationError`.
- [x] Ruff + Black + import-boundary green.