### PR TITLE
feat(adapter): bridge Tool.policy.timeout_s to ToolSchema.timeout_s

### DIFF
--- a/docs/TASK_DESCRIPTION_SCHEMA.md
+++ b/docs/TASK_DESCRIPTION_SCHEMA.md
@@ -105,11 +105,10 @@ shipped one that performs I/O does — is banded at its own budget plus a fixed
 grace instead, and this field plays no part. So a `bash_session` is bounded by
 its `tool_config.timeout_s` (ADR-0017), not by this.
 
-It is not pack-declarable either way: `NativeAdapter` builds every tool's schema
-with the model default, so a pack cannot influence the value — tracked in
-[#1147](https://github.com/Toloka/tolokaforge/issues/1147). The one budget a pack
-can set today is `bash_session`'s `tool_config.timeout_s` (see
-[`docs/TOOLS.md`](TOOLS.md)).
+`NativeAdapter` builds every builtin's schema with the tool's own
+`ToolPolicy.timeout_s`, so a builtin's declared budget reaches the runner as
+its emitted `ToolSchema.timeout_s`. The one budget a pack can set today is
+`bash_session`'s `tool_config.timeout_s` (see [`docs/TOOLS.md`](TOOLS.md)).
 
 `ToolSchema.output_max_chars` is the per-tool cap the runner returns to the
 harness for the tool's `role=tool` message content. The engine loop composes it

--- a/docs/adr/0017-persistent-agent-shell-and-editor-tools.md
+++ b/docs/adr/0017-persistent-agent-shell-and-editor-tools.md
@@ -200,8 +200,8 @@ sentinel line and parses the trailing exit code.
 (`timeout_s`). This is the control the tool applies to itself; the runner's
 backstop (`ToolWrapper.effective_timeout_s`) sits a fixed grace above it, so the
 tool's own kill-safe termination is what fires. The tool's `ToolSchema.timeout_s`
-plays no part — a native pack pins it to 30 s for every builtin (#1147), which is
-why this budget is read from tool config.
+does not gate the command — `PersistentShellToolWrapper` names the tool-config
+`timeout_s` as its `own_budget_s`, which the backstop bands above.
 
 **Kill-safety.** On timeout the running command is killed (a signal to the
 foreground command's process group) **without leaking the parent shell** —

--- a/tests/unit/test_native_adapter_builtin_dispatch.py
+++ b/tests/unit/test_native_adapter_builtin_dispatch.py
@@ -536,3 +536,93 @@ def test_tool_output_max_chars_override_rejects_non_positive_int(tmp_path: Path,
 
     with pytest.raises(ValueError, match=r"tools\.agent\.stub\.output_max_chars"):
         tool_output_max_chars_overrides(task, ToolActor.AGENT)
+
+
+# ---------------------------------------------------------------------------
+# ToolPolicy.timeout_s — adapter bridge
+# ---------------------------------------------------------------------------
+
+
+class _StubShortTimeoutTool:
+    """Stub builtin whose ``policy.timeout_s`` declares a tight per-tool budget."""
+
+    def __init__(self) -> None:
+        from tolokaforge.tools.registry import ToolPolicy
+
+        self.policy = ToolPolicy(timeout_s=5.0)
+
+    def get_schema(self) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": "stub_short_timeout",
+                "description": "A stub tool with a tight timeout.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+
+def test_builtin_tool_schemas_lifts_timeout_s_from_policy(monkeypatch):
+    """A builtin whose ``ToolPolicy`` declares a per-tool ``timeout_s`` surfaces
+    the value on the rich schema ``_builtin_tool_schemas`` returns, so
+    ``_actor_tool_schemas`` can lift it onto the emitted ``ToolSchema``.
+    """
+    from tolokaforge.tools.builtin import registry as builtin_registry
+
+    monkeypatch.setattr(builtin_registry, "is_builtin", lambda name: name == "stub_short_timeout")
+    monkeypatch.setattr(builtin_registry, "get_class", lambda name: _StubShortTimeoutTool)
+
+    schemas = _builtin_tool_schemas(["stub_short_timeout"])
+
+    assert schemas["stub_short_timeout"]["timeout_s"] == 5.0
+
+
+def test_builtin_tool_schemas_lifts_default_when_policy_is_default():
+    """A shipped builtin whose ``ToolPolicy`` leaves ``timeout_s`` at the class
+    default (30.0) surfaces 30.0 on the rich schema, so the adapter emits
+    ``ToolSchema.timeout_s == 30.0`` — matching the ``ToolPolicy.timeout_s``
+    field default. ``bash`` is the canonical example.
+    """
+    schemas = _builtin_tool_schemas(["bash"])
+
+    assert schemas["bash"]["timeout_s"] == 30.0
+
+
+def test_native_adapter_emits_declared_timeout_s_on_the_wire_toolschema(
+    monkeypatch, tmp_path: Path
+):
+    """The full adapter path: a builtin whose ``ToolPolicy.timeout_s`` is 5.0
+    surfaces on the ``ToolSchema`` NativeAdapter emits into the wire payload the
+    runner will send back at ``RegisterTrial``.
+    """
+    from tolokaforge.tools.builtin import registry as builtin_registry
+
+    monkeypatch.setattr(builtin_registry, "is_builtin", lambda name: name == "stub_short_timeout")
+    monkeypatch.setattr(builtin_registry, "get_class", lambda name: _StubShortTimeoutTool)
+
+    task_dir = tmp_path / "short_timeout_task"
+    task_dir.mkdir()
+    (task_dir / "task.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "task_id": "short_timeout_task",
+                "name": "short-timeout task",
+                "description": "one builtin with a tight policy timeout",
+                "category": "compute",
+                "max_turns": 2,
+                "interaction_mode": "conversational",
+                "initial_user_message": "poll",
+                "initial_state": {},
+                "tools": {
+                    "agent": {"enabled": ["stub_short_timeout"]},
+                    "user": {"enabled": []},
+                },
+                "actors": {"user": {"mode": "llm"}},
+            }
+        )
+    )
+    adapter = NativeAdapter({"tasks_glob": "*/task.yaml", "base_dir": str(tmp_path)})
+    td = adapter.to_task_description("short_timeout_task")
+
+    stub = next(t for t in td.agent_tools if t.name == "stub_short_timeout")
+    assert stub.timeout_s == 5.0

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -1146,6 +1146,7 @@ def _builtin_tool_schemas(
                 "description": func_def.get("description", f"Builtin tool: {name}"),
                 "parameters": func_def.get("parameters", {"type": "object", "properties": {}}),
                 "output_max_chars": tool.policy.output_max_chars,
+                "timeout_s": tool.policy.timeout_s,
             }
         except Exception as exc:
             logger.debug("Could not load builtin schema", tool_name=name, error=str(exc))

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -245,7 +245,7 @@ def _actor_tool_schemas(task: TaskConfig, task_dir: Path, actor: ToolActor) -> l
                 ),
                 parameters=rich.get("parameters", {"type": "object", "properties": {}}),
                 category="compute",
-                timeout_s=30.0,
+                timeout_s=rich.get("timeout_s", 30.0),
                 source=source,
                 tool_config=configs.get(tool_name, {}),
                 output_max_chars=emitted_cap,


### PR DESCRIPTION
## Summary

Replaces the hardcoded `timeout_s=30.0` in `NativeAdapter._actor_tool_schemas` with `rich.get("timeout_s", 30.0)`, and extends `_builtin_tool_schemas` to lift `tool.policy.timeout_s` into the rich dict — mirror of the M48 `output_max_chars` bridge. Every builtin's declared `ToolPolicy.timeout_s` now reaches the wire.

Closes #1556.

## Design choices

| Decision | Rationale |
|---|---|
| Bridge all 14 tightening builtins unconditionally | The 30 s hardcode was an accident of `_actor_tool_schemas`, not a design choice. Every tightening aligns the runner with what the tool author declared. |
| Rich-dict lift + `rich.get(..., 30.0)` fallback | Mirrors the sibling `output_max_chars` bridge shape from #1503. Fallback default 30.0 matches `ToolPolicy.timeout_s` field default at `registry.py:186`, so a builtin whose rich dict never surfaced a value stays at today's behaviour. |
| Skip `search_kb` and `bash_session` | `create_search_kb_schema()` bypasses `_builtin_tool_schemas` entirely (tracked as #1565). `PersistentShellToolWrapper` reads its own timeout from `tool_config` (default 120), not `self.timeout_s`, so `bash_session` is unaffected by design. |
| No `BuiltinFileToolWrapper` grace band in this PR | `read_file` / `write_file` / `list_dir` tighten 30 s → 10 s (no grace, sharpest cut). The grace-band parity fix lands separately as #1564 to keep this PR scoped. |

## Effective-timeout audit (post-bridge)

Fourteen builtins tighten:
- `read_file`, `write_file`, `list_dir`: 30 → 10 s (no grace — sharpest cut)
- `calculator`: 30 → 10 s (5 s policy + 5 s grace)
- `replace_lines`, `append_file`, `move_file`, `copy_file`, `delete_file`, `db_query`, `db_update`, `get_db_schema`: 30 → 15 s
- `grep_workspace`: 30 → 20 s
- `http_request`: 30 → 25 s

No change: `bash`, `browser`, `sql_query`, `build_check`, `bash_session`, `str_replace_editor`, `search_kb`, `mobile` (inherits BrowserTool policy at 60.0).

## Test plan
- [x] Unit: `test_builtin_tool_schemas_lifts_timeout_s_from_policy` — a stubbed builtin with `ToolPolicy(timeout_s=5.0)` surfaces `5.0` on the rich schema.
- [x] Unit: `test_builtin_tool_schemas_lifts_default_when_policy_is_default` — a shipped builtin (`bash`) surfaces `30.0`, locking the default path.
- [x] Unit: `test_native_adapter_emits_declared_timeout_s_on_the_wire_toolschema` — full adapter path: emitted `ToolSchema.timeout_s == 5.0` for a stub with policy 5.0.
- [x] `mcp__dev__run_tests marker=unit paths=tests/unit/test_native_adapter_builtin_dispatch.py` passes.
- [x] Ruff + Black + import-boundary green.

## #1147 partial discharge

#1147 stays OPEN. This bridge kills the "30 s pin" clause (title clause 2) but leaves pack-declared per-tool timeouts unimplemented (title clause 1 — a pack still cannot override a tool's policy value; that would need a task-yaml override in the shape of #1554 for `output_max_chars`). Deferring #1147 closure or a follow-up ticket to the maintainer.

## Follow-ups filed alongside this PR

- #1564 — `BuiltinFileToolWrapper` grace-band parity (adds 5 s grace to `read_file` / `write_file` / `list_dir`).
- #1565 — `create_search_kb_schema()` hardcodes `timeout_s=15.0` beside `SearchKBTool.policy.timeout_s = 15.0` — silent drift risk.