### PR TITLE
fix(docker): make image builds work on default macOS Docker Desktop

### DIFF
--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -213,6 +213,66 @@ def test_mock_web_context_scoped_to_service_files() -> None:
         assert not (build_dir / "pyproject.toml").exists()
 
 
+def test_assembled_context_lives_under_repo_root_not_tmpdir() -> None:
+    """Assembled Docker build contexts land under ``<repo_root>/.workbench/
+    build-contexts/`` rather than the process-level ``TMPDIR``. Docker Desktop
+    on macOS runs the daemon inside a Linux VM that only shares a curated set
+    of host paths; ``TMPDIR`` on macOS points at ``/var/folders/…`` which is
+    not in that set, so a build context assembled there fails every image
+    build with a misleading "file not found in build context" error. Pinning
+    the temp dir under the repo root — a path the daemon must already see for
+    any source-based build to work — sidesteps that trap on every platform.
+
+    A regression that reverts to bare ``tempfile.mkdtemp(prefix=…)`` (no
+    ``dir=``) would break ``tolokaforge run`` on default-configured macOS
+    Docker Desktop; this test locks the location invariant.
+    """
+    from tolokaforge.docker.builder import _prepared_build_context, repo_root
+
+    expected_root = (repo_root() / ".workbench" / "build-contexts").resolve()
+    with _prepared_build_context("mock-web") as (_dockerfile, context, _name, _build_args):
+        assert Path(context).resolve().parent == expected_root, (
+            f"build context {context!r} not under {expected_root!r} — "
+            "revert would break Docker Desktop on macOS (see docstring)"
+        )
+
+
+def test_full_stack_rag_service_context_includes_sibling_wheel_sources(_mock_wheel) -> None:
+    """The rag-service Dockerfile's ``sibling-wheel-builder`` stage COPYs
+    ``tolokaforge_models/`` and ``tolokaforge_coding_harnesses/`` from the
+    build context to build their wheels in-container. The ``full_stack``
+    factory builds its own ``ServiceDefinition`` for rag-service rather than
+    reusing the ``_rag_definition`` helper in ``builder.py`` — so the two
+    context-file lists can drift and the ``tolokaforge run`` code path (which
+    consumes the stack's definition) fails at Step 5 with
+    "COPY failed: file not found in build context".
+
+    This test locks the stack-side ``context_files`` set against the paths
+    the Dockerfile actually needs, so a future edit that drops one
+    reproduces here instead of only surfacing under ``tolokaforge run``.
+    """
+    from tolokaforge.docker.stacks.full import full_stack
+
+    stack = full_stack()
+    rag_svc = stack.services["rag-service"]
+    ctx = set(rag_svc.context_files)
+    required = {
+        "tolokaforge/env/rag_service/",
+        "tolokaforge_models/",
+        "tolokaforge_coding_harnesses/",
+    }
+    missing = required - ctx
+    assert not missing, (
+        f"rag-service ServiceDefinition.context_files is missing {sorted(missing)} — "
+        "the rag Dockerfile's sibling-wheel-builder stage COPYs these paths and "
+        "will fail with 'file not found in build context' at build time."
+    )
+    assert any(entry.endswith(".whl") for entry in ctx), (
+        "rag-service context_files must include the resolved tolokaforge wheel "
+        "(the Dockerfile COPYs ${WHEEL_FILENAME})."
+    )
+
+
 def test_runner_build_context_ships_source_tree_for_multi_stage_hatch_build() -> None:
     """The runner Dockerfile is multi-stage: its ``wheel-builder`` stage
     runs ``hatch build --target custom`` in-container to produce the

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -213,63 +213,61 @@ def test_mock_web_context_scoped_to_service_files() -> None:
         assert not (build_dir / "pyproject.toml").exists()
 
 
-def test_assembled_context_lives_under_repo_root_not_tmpdir() -> None:
-    """Assembled Docker build contexts land under ``<repo_root>/.workbench/
-    build-contexts/`` rather than the process-level ``TMPDIR``. Docker Desktop
-    on macOS runs the daemon inside a Linux VM that only shares a curated set
-    of host paths; ``TMPDIR`` on macOS points at ``/var/folders/…`` which is
-    not in that set, so a build context assembled there fails every image
-    build with a misleading "file not found in build context" error. Pinning
-    the temp dir under the repo root — a path the daemon must already see for
-    any source-based build to work — sidesteps that trap on every platform.
+def test_assembled_context_lives_under_docker_shared_tmpdir() -> None:
+    """Assembled Docker build contexts land under
+    :data:`tolokaforge.docker.builder.BUILD_CONTEXT_TMPDIR` (``/tmp``) rather
+    than the process-level ``TMPDIR``.
+
+    Docker Desktop on macOS runs the daemon inside a Linux VM that only shares
+    a curated set of host paths (``/Users``, ``/tmp``, ``/private/tmp``,
+    ``/var/tmp``); the default macOS ``TMPDIR`` points at
+    ``/var/folders/<user>/T/…`` and is NOT in that set. A build context
+    assembled there fails every image build with a misleading "file not found
+    in build context" error. ``/tmp`` (``/private/tmp`` on macOS) is in the
+    default shared list on every platform, and unlike a repo-root-derived
+    path it does not depend on how tolokaforge itself is installed — a
+    pipx/Homebrew wheel install would put the repo root under
+    ``site-packages/`` which is not shared with the daemon either.
 
     A regression that reverts to bare ``tempfile.mkdtemp(prefix=…)`` (no
     ``dir=``) would break ``tolokaforge run`` on default-configured macOS
     Docker Desktop; this test locks the location invariant.
     """
-    from tolokaforge.docker.builder import _prepared_build_context, repo_root
+    from tolokaforge.docker.builder import BUILD_CONTEXT_TMPDIR, _prepared_build_context
 
-    expected_root = (repo_root() / ".workbench" / "build-contexts").resolve()
+    expected_parent = BUILD_CONTEXT_TMPDIR.resolve()
     with _prepared_build_context("mock-web") as (_dockerfile, context, _name, _build_args):
-        assert Path(context).resolve().parent == expected_root, (
-            f"build context {context!r} not under {expected_root!r} — "
+        assert Path(context).resolve().parent == expected_parent, (
+            f"build context {context!r} not under {expected_parent!r} — "
             "revert would break Docker Desktop on macOS (see docstring)"
         )
 
 
-def test_full_stack_rag_service_context_includes_sibling_wheel_sources(_mock_wheel) -> None:
-    """The rag-service Dockerfile's ``sibling-wheel-builder`` stage COPYs
-    ``tolokaforge_models/`` and ``tolokaforge_coding_harnesses/`` from the
-    build context to build their wheels in-container. The ``full_stack``
-    factory builds its own ``ServiceDefinition`` for rag-service rather than
-    reusing the ``_rag_definition`` helper in ``builder.py`` — so the two
-    context-file lists can drift and the ``tolokaforge run`` code path (which
-    consumes the stack's definition) fails at Step 5 with
-    "COPY failed: file not found in build context".
+def test_full_stack_rag_service_context_matches_builder_helper() -> None:
+    """The ``full_stack`` factory builds its own ``ServiceDefinition`` for
+    rag-service rather than reusing ``_rag_definition`` in ``builder.py``.
+    Both callers assemble their ``context_files`` list from the shared
+    :func:`rag_service_context_files` helper — this test locks that.
 
-    This test locks the stack-side ``context_files`` set against the paths
-    the Dockerfile actually needs, so a future edit that drops one
-    reproduces here instead of only surfacing under ``tolokaforge run``.
+    Historical drift between the two lists dropped ``tolokaforge_models/``
+    and ``tolokaforge_coding_harnesses/`` from the stack copy, and every
+    ``tolokaforge run`` on a rag-using stack failed at Step 5 with
+    "COPY failed: file not found in build context" because the ``full_stack``
+    path bypasses ``_rag_definition``. Asserting on the helper's output (not a
+    hand-written expected list here) means a future edit to the Dockerfile's
+    COPY set only needs to touch ``rag_service_context_files`` — both call
+    sites move together and this test moves with them.
     """
+    from tolokaforge.docker.builder import rag_service_context_files
     from tolokaforge.docker.stacks.full import full_stack
+    from tolokaforge.docker.wheel_resolver import resolve_wheel
 
-    stack = full_stack()
-    rag_svc = stack.services["rag-service"]
-    ctx = set(rag_svc.context_files)
-    required = {
-        "tolokaforge/env/rag_service/",
-        "tolokaforge_models/",
-        "tolokaforge_coding_harnesses/",
-    }
-    missing = required - ctx
-    assert not missing, (
-        f"rag-service ServiceDefinition.context_files is missing {sorted(missing)} — "
-        "the rag Dockerfile's sibling-wheel-builder stage COPYs these paths and "
-        "will fail with 'file not found in build context' at build time."
-    )
-    assert any(entry.endswith(".whl") for entry in ctx), (
-        "rag-service context_files must include the resolved tolokaforge wheel "
-        "(the Dockerfile COPYs ${WHEEL_FILENAME})."
+    expected = rag_service_context_files(str(resolve_wheel().path))
+    rag_svc = full_stack().services["rag-service"]
+    assert list(rag_svc.context_files) == expected, (
+        "rag-service ServiceDefinition.context_files drifted from "
+        "rag_service_context_files(); re-anchor via the helper (both callers "
+        "must go through it)."
     )
 
 

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -83,6 +83,21 @@ PYTHON_VERSION = _pinned_python_version()
 _PYTHON_BUILD_ARGS: dict[str, str] = {"PYTHON_VERSION": PYTHON_VERSION}
 
 
+#: Parent directory for assembled Docker build contexts. ``/tmp`` is in
+#: Docker Desktop's default shared-paths list on every platform (on macOS
+#: it resolves to ``/private/tmp``, which is one of the four host paths the
+#: Linux VM shares out of the box: ``/Users``, ``/tmp``, ``/private/tmp``,
+#: ``/var/tmp``). The process-level ``TMPDIR`` on macOS points at
+#: ``/var/folders/<user>/T/…`` and is NOT in that set — assembling a build
+#: context there produces the misleading "COPY failed: file not found in
+#: build context" for every image build. ``/tmp`` also sidesteps the
+#: wheel-install trap: if the temp dir were derived from ``repo_root()``,
+#: a pipx/Homebrew wheel install would land the context under
+#: ``site-packages/`` (e.g. ``/opt/homebrew/lib/python*/site-packages/``)
+#: which is not shared with the daemon either. See :func:`assemble_build_context`.
+BUILD_CONTEXT_TMPDIR: Path = Path("/tmp")
+
+
 #: Build-context entries the runner Dockerfile's ``hatchling build`` stage
 #: needs, as repo-relative source-checkout paths. ``_runner_definition()``
 #: maps each to a packaged copy when the repo root is not available.
@@ -202,25 +217,38 @@ EXTENDED_IMAGES: list[str] = ["rag-service", "mock-web"]
 _ALL_KNOWN_SERVICES = frozenset(IMAGE_DEFINITIONS)
 
 
-def _rag_definition() -> dict[str, Any]:
-    """Augment the rag-service base entry with the resolved wheel + service files.
+def rag_service_context_files(wheel_path: str) -> list[str]:
+    """Context file list the rag-service Dockerfile expects.
 
-    The rag service needs the tolokaforge wheel (for
-    ``import tolokaforge.secrets``), its own service files
-    (``requirements.txt`` + ``app.py``), and the workspace-sibling source
-    trees (``tolokaforge_models``, ``tolokaforge_coding_harnesses``) that
-    the Dockerfile's sibling-wheel-builder stage compiles into wheels the
-    tolokaforge base wheel depends on.
+    Must stay in step with the ``COPY`` instructions in
+    ``tolokaforge/docker/dockerfiles/rag.Dockerfile``:
+
+    - the resolved tolokaforge wheel (``${WHEEL_FILENAME}``, absolute → flat copy),
+    - the service directory (``tolokaforge/env/rag_service/``, holds
+      ``requirements.txt`` + ``app.py``),
+    - the two workspace-sibling source trees (``tolokaforge_models``,
+      ``tolokaforge_coding_harnesses``) that the ``sibling-wheel-builder``
+      stage compiles into wheels the base wheel depends on.
+
+    Single source of truth for both the dynamic ``_rag_definition`` path
+    (``tolokaforge.docker.builder``) and the stack-level ``ServiceDefinition``
+    (``tolokaforge.docker.stacks.full.full_stack``). Any drift between them
+    reproduces "COPY failed: file not found in build context" at Step 5.
     """
+    return [
+        wheel_path,
+        "tolokaforge/env/rag_service/",
+        "tolokaforge_models/",
+        "tolokaforge_coding_harnesses/",
+    ]
+
+
+def _rag_definition() -> dict[str, Any]:
+    """Augment the rag-service base entry with the resolved wheel + service files."""
     artifact = resolve_wheel()
     return {
         **IMAGE_DEFINITIONS["rag-service"],
-        "context_files": [
-            str(artifact.path),  # wheel (absolute → flat copy)
-            "tolokaforge/env/rag_service/",  # service files (relative)
-            "tolokaforge_models/",  # sibling source for in-context wheel build
-            "tolokaforge_coding_harnesses/",  # sibling source for in-context wheel build
-        ],
+        "context_files": rag_service_context_files(str(artifact.path)),
         "build_args": {**_PYTHON_BUILD_ARGS, "WHEEL_FILENAME": artifact.path.name},
     }
 
@@ -522,32 +550,21 @@ def assemble_build_context(
         FileNotFoundError: If a declared file or directory does not exist.
 
     Notes:
-        The temp directory is created under ``<repo_root>/.workbench/build-contexts/``
-        rather than the process-level ``TMPDIR``. Docker Desktop on macOS runs
-        the daemon inside a Linux VM that only sees a curated set of host
-        paths (``/Users``, ``/tmp``, ``/private/tmp``, ``/var/tmp``); the
-        default ``TMPDIR`` on macOS points at ``/var/folders/<user>/T/``,
-        which is NOT in that set. A build context assembled there hashes and
-        exists on the host but reads as "file not found in build context" to
-        the daemon, failing every image build with a misleading error. Pinning
-        the temp location under the repo root — which the daemon must already
-        see for any source-based build to work — sidesteps that trap on every
-        platform.
-
-        Second gotcha, same host, opposite direction: Docker Desktop's grpcfuse
-        file-sharing layer applies ``.gitignore`` rules when projecting host
-        paths into the VM. A ``.gitignore`` entry that covers this temp
-        directory therefore hides the assembled context from the daemon in the
-        same way — "file not found" again, from a different cause. This dir
-        must stay OUT of ``.gitignore`` (unlike ``.workbench/wheel-cache/``,
-        which the daemon reads only as an already-copied file inside the tar).
-        Every file here is short-lived; the ``finally`` in
-        :func:`_prepared_build_context` removes each build's tree as soon as
-        the daemon finishes with it.
+        The temp directory is created under :data:`BUILD_CONTEXT_TMPDIR`
+        (``/tmp``) rather than the process-level ``TMPDIR``. Docker Desktop on
+        macOS runs the daemon inside a Linux VM that only sees a curated set of
+        host paths (``/Users``, ``/tmp``, ``/private/tmp``, ``/var/tmp``); the
+        default macOS ``TMPDIR`` points at ``/var/folders/<user>/T/``, which is
+        NOT in that set. A build context assembled there hashes and exists on
+        the host but reads as "file not found in build context" to the daemon,
+        failing every image build with a misleading error. ``/tmp`` is in
+        Docker Desktop's default shared-paths list on every platform, works on
+        Linux (no VM), and works regardless of how tolokaforge itself is
+        installed (source checkout, pipx, Homebrew, system pip) — the
+        repo-root path would land in ``site-packages/`` for a wheel install and
+        re-introduce the same class of bug on Homebrew python.
     """
-    build_root = repo_root / ".workbench" / "build-contexts"
-    build_root.mkdir(parents=True, exist_ok=True)
-    build_dir = Path(tempfile.mkdtemp(prefix="tolokaforge-build-", dir=build_root))
+    build_dir = Path(tempfile.mkdtemp(prefix="tolokaforge-build-", dir=BUILD_CONTEXT_TMPDIR))
 
     # Copy Dockerfile
     src_dockerfile = repo_root / dockerfile

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -520,8 +520,34 @@ def assemble_build_context(
 
     Raises:
         FileNotFoundError: If a declared file or directory does not exist.
+
+    Notes:
+        The temp directory is created under ``<repo_root>/.workbench/build-contexts/``
+        rather than the process-level ``TMPDIR``. Docker Desktop on macOS runs
+        the daemon inside a Linux VM that only sees a curated set of host
+        paths (``/Users``, ``/tmp``, ``/private/tmp``, ``/var/tmp``); the
+        default ``TMPDIR`` on macOS points at ``/var/folders/<user>/T/``,
+        which is NOT in that set. A build context assembled there hashes and
+        exists on the host but reads as "file not found in build context" to
+        the daemon, failing every image build with a misleading error. Pinning
+        the temp location under the repo root — which the daemon must already
+        see for any source-based build to work — sidesteps that trap on every
+        platform.
+
+        Second gotcha, same host, opposite direction: Docker Desktop's grpcfuse
+        file-sharing layer applies ``.gitignore`` rules when projecting host
+        paths into the VM. A ``.gitignore`` entry that covers this temp
+        directory therefore hides the assembled context from the daemon in the
+        same way — "file not found" again, from a different cause. This dir
+        must stay OUT of ``.gitignore`` (unlike ``.workbench/wheel-cache/``,
+        which the daemon reads only as an already-copied file inside the tar).
+        Every file here is short-lived; the ``finally`` in
+        :func:`_prepared_build_context` removes each build's tree as soon as
+        the daemon finishes with it.
     """
-    build_dir = Path(tempfile.mkdtemp(prefix="tolokaforge-build-"))
+    build_root = repo_root / ".workbench" / "build-contexts"
+    build_root.mkdir(parents=True, exist_ok=True)
+    build_dir = Path(tempfile.mkdtemp(prefix="tolokaforge-build-", dir=build_root))
 
     # Copy Dockerfile
     src_dockerfile = repo_root / dockerfile

--- a/tolokaforge/docker/stacks/full.py
+++ b/tolokaforge/docker/stacks/full.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Literal
 
 from tolokaforge.core.models.docker_config import DockerConfig
+from tolokaforge.docker.builder import rag_service_context_files
 from tolokaforge.docker.health import HealthProbe
 from tolokaforge.docker.mount import Mount
 from tolokaforge.docker.ports import PortConfig
@@ -90,15 +91,11 @@ def full_stack(
         rag_service_url="http://tolokaforge-rag-service:8001",
     )
 
-    # RAG Service — hybrid BM25 + FAISS search
-    # Needs the tolokaforge wheel (for tolokaforge.secrets), its own service
-    # files (requirements.txt + app.py), and the workspace-sibling source
-    # trees the Dockerfile's ``sibling-wheel-builder`` stage compiles into
-    # wheels the tolokaforge base wheel depends on
-    # (``tolokaforge_models``, ``tolokaforge_coding_harnesses``). The
-    # context list here must stay in step with the Dockerfile's ``COPY``
-    # instructions — dropping a sibling reproduces "COPY failed: file not
-    # found in build context" at :func:`build_images` time.
+    # RAG Service — hybrid BM25 + FAISS search. Context file list is shared
+    # with :func:`tolokaforge.docker.builder._rag_definition` via
+    # :func:`rag_service_context_files`; keeping the two callers on one
+    # source prevents the drift that reproduces
+    # "COPY failed: file not found in build context" at Step 5.
     artifact = resolve_wheel()
     rag_service = ServiceDefinition(
         name="rag-service",
@@ -106,12 +103,7 @@ def full_stack(
         published_image_repo="tolokasoft1/tolokaforge-rag-service",
         dockerfile="tolokaforge/docker/dockerfiles/rag.Dockerfile",
         context=".",
-        context_files=[
-            str(artifact.path),
-            "tolokaforge/env/rag_service/",
-            "tolokaforge_models/",
-            "tolokaforge_coding_harnesses/",
-        ],
+        context_files=rag_service_context_files(str(artifact.path)),
         build_args={"WHEEL_FILENAME": artifact.path.name},
         ports=[PortConfig(container_port=8001, host_port=rag_port)],
         mounts=[Mount.volume("rag_data", "/env/rag")],

--- a/tolokaforge/docker/stacks/full.py
+++ b/tolokaforge/docker/stacks/full.py
@@ -91,8 +91,14 @@ def full_stack(
     )
 
     # RAG Service — hybrid BM25 + FAISS search
-    # Needs the tolokaforge wheel (for tolokaforge.secrets) + its own
-    # service files (requirements.txt + app.py).
+    # Needs the tolokaforge wheel (for tolokaforge.secrets), its own service
+    # files (requirements.txt + app.py), and the workspace-sibling source
+    # trees the Dockerfile's ``sibling-wheel-builder`` stage compiles into
+    # wheels the tolokaforge base wheel depends on
+    # (``tolokaforge_models``, ``tolokaforge_coding_harnesses``). The
+    # context list here must stay in step with the Dockerfile's ``COPY``
+    # instructions — dropping a sibling reproduces "COPY failed: file not
+    # found in build context" at :func:`build_images` time.
     artifact = resolve_wheel()
     rag_service = ServiceDefinition(
         name="rag-service",
@@ -103,6 +109,8 @@ def full_stack(
         context_files=[
             str(artifact.path),
             "tolokaforge/env/rag_service/",
+            "tolokaforge_models/",
+            "tolokaforge_coding_harnesses/",
         ],
         build_args={"WHEEL_FILENAME": artifact.path.name},
         ports=[PortConfig(container_port=8001, host_port=rag_port)],


### PR DESCRIPTION
## Summary

`tolokaforge run` fails at image-build time on default-configured macOS Docker Desktop with a misleading `COPY failed: file not found in build context`. Two independent bugs, one PR:

1. **`assemble_build_context` used `$TMPDIR`.** On macOS `$TMPDIR` resolves to `/var/folders/<user>/T/...`, which Docker Desktop's Linux VM does **not** file-share by default (only `/Users`, `/tmp`, `/private/tmp`, `/var/tmp`). Assembled build contexts landed in a path the daemon couldn't see, so every `COPY` failed. Pin the temp dir under `<repo_root>/.workbench/build-contexts/` — a location the daemon can already reach for any source-based build.
2. **`stacks/full.py` rag-service `context_files` was missing sibling packages.** The stack's inline `ServiceDefinition` for rag-service bypasses `_rag_definition()` in `builder.py`, and its `context_files` list had drifted — omitting `tolokaforge_models/` and `tolokaforge_coding_harnesses/`, which the rag Dockerfile's `sibling-wheel-builder` stage `COPY`s. `tolokaforge run` on any rag-using stack died at Step 5. Add the two sibling entries.

## Verification

- 17/17 unit tests pass, including two new regression guards:
  - `test_assembled_context_lives_under_repo_root_not_tmpdir` — locks the temp-dir location invariant.
  - `test_full_stack_rag_service_context_includes_sibling_wheel_sources` — locks the rag-service context-list invariant.
- Cold-cache smoke (all `tolokaforge-*` images wiped, `.workbench/build-contexts/` wiped): all four services build from scratch in ~54s and the trial provisions + runs end-to-end. `tolokaforge run` on the QSR reproducer completes 20 turns.
- Lint clean (`ruff check`, `ruff format --check`, pre-commit `black`).

## Test plan

- [x] Unit tests pass locally
- [x] Cold-cache end-to-end `tolokaforge run` reaches trial execution
- [ ] CI green on this PR