### PR TITLE
fix(examples): declare on_missing: fail on the notes gate constraint

### DIFF
--- a/examples/native/native_shared_domain/dataset/notes/testcases/add_note_duplicate_check_gated/grading.yaml
+++ b/examples/native/native_shared_domain/dataset/notes/testcases/add_note_duplicate_check_gated/grading.yaml
@@ -43,6 +43,11 @@ trace_checks:
     - id: the_notes_were_listed_before_the_note_was_added
       description: "the assistant listed the existing notes before it added a new one"
       severity: gate
+      # Explicit accept-the-risk: the whole point of the gate demo is that a
+      # missing list_notes call fails the trial, so we treat a silent tool
+      # error the same way. If list_notes were flaky in a real pack, this
+      # would be `on_missing: withhold` instead.
+      on_missing: fail
       require:
         before:
           left:

--- a/examples/native/native_shared_domain/dataset/notes/testcases/add_note_duplicate_check_policy/grading.yaml
+++ b/examples/native/native_shared_domain/dataset/notes/testcases/add_note_duplicate_check_policy/grading.yaml
@@ -39,6 +39,11 @@ trace_checks:
     - id: the_notes_were_listed_before_the_note_was_added
       description: "the assistant listed the existing notes before it added a new one"
       severity: gate
+      # Explicit accept-the-risk: the whole point of the gate demo is that a
+      # missing list_notes call fails the trial, so we treat a silent tool
+      # error the same way. Mirrors add_note_duplicate_check_gated/grading.yaml
+      # — the two arms must stay identical on every graded block.
+      on_missing: fail
       require:
         before:
           left:


### PR DESCRIPTION
## Summary

`tolokaforge validate` on `examples/native/**/task.yaml` rejects the two notes duplicate-check testcases because the shipped v0.24.1 trace_checks advisory (arena v3 residuals, #1560) refuses to leave \`on_missing\` implicit when \`severity: gate\` is declared. Both testcases intentionally use the \`list_notes\` anchor to demonstrate the gate firing when the model skips the list-first step, so the explicit choice is \`on_missing: fail\` — accept the risk that a silent tool error looks like a skip. The two arms must stay identical on every graded block, so the same declaration lands in both.

## Why this matters

Release Gate and CI's *Validate public example suites* step both failed on the v0.24.2 release commit (\`c6e1a790\`) at exactly this check. The wheel + sdist published anyway because those workflows are independent of the gate, but the red workflows are the fix target here.

## Verification

- \`uv run tolokaforge validate --tasks \"examples/native/*/dataset/**/task.yaml\"\` — every task ✓ locally.
- \`uv run pytest tests/canonical/test_rubric_migration.py\` — 52/52 pass (the guard that pins the two arms to identical graded blocks).

## Test plan

- [x] Local validate green
- [x] Canonical rubric-migration guard green
- [ ] CI green on this PR