### PR TITLE
feat(grading): JudgeKind Protocol + registry + SingleShotRubricJudgeKind (#1566)

### DIFF
--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -556,7 +556,7 @@ import anywhere under `composite/` trips at pytest collection.
 | --- | --- | --- | --- |
 | `tolokaforge.custom_check_executors` | [`check_runner.py::CheckExecutor`](../tolokaforge/core/grading/check_runner.py) | `CheckRunner` (production), `InMemoryCheckExecutor` (test fixture) | holistic |
 | `tolokaforge.judge_model_providers` | [`judge_model_provider.py::JudgeModelProvider`](../tolokaforge/core/grading/judge_model_provider.py) | `LiteLLMJudgeModelProvider` (fronts `LLMClient`) | holistic |
-| `tolokaforge.rubric_evaluators` | [`rubric_evaluator.py::RubricEvaluator`](../tolokaforge/core/grading/rubric_evaluator.py) | `LLMJudgeRubricEvaluator` (wraps `LLMJudge`) | holistic |
+| `tolokaforge.judge_kinds` | [`judge_kinds/_protocol.py::JudgeKind`](../tolokaforge/core/grading/judge_kinds/_protocol.py) | `SingleShotRubricJudgeKind` (wraps `LLMJudge` in one shot) | holistic |
 | `tolokaforge.transcript_rule_matchers` | [`transcript_rule_matcher.py::TranscriptRuleMatcher`](../tolokaforge/core/grading/transcript_rule_matcher.py) | `DefaultTranscriptRuleMatcher` (wraps `evaluate_transcript_rules`) | holistic |
 | `tolokaforge.trace_check_operators` | [`trace_check_operator.py::TraceCheckOperator`](../tolokaforge/core/grading/trace_check_operator.py) | the shipped trace-check operators — non-binding and binding forms — registered via the entry-point group; see [`GRADING.md` § Operators](GRADING.md#operators) for the authored vocabulary | per-operator |
 | `tolokaforge.state_check_backends` | [`state_check_backend.py::StateCheckBackend`](../tolokaforge/core/grading/state_check_backend.py) | `JsonpathStateCheckBackend`, `DbProbesStateCheckBackend` (hash is NOT a backend — runner-integrated) | per-source |
@@ -568,8 +568,8 @@ Register a downstream impl the same way as a `TrialGrader`:
 [project.entry-points."tolokaforge.judge_model_providers"]
 openai_direct = "acme_judge:_openai_direct_provider_factory"
 
-[project.entry-points."tolokaforge.rubric_evaluators"]
-deterministic_rules = "acme_grader:_rules_evaluator_factory"
+[project.entry-points."tolokaforge.judge_kinds"]
+chunked_rubric = "acme_grader:ChunkedRubricJudgeKind"
 
 [project.entry-points."tolokaforge.state_check_backends"]
 s3_diff = "acme_grader:_s3_diff_state_check_backend_factory"
@@ -582,11 +582,13 @@ The runner resolves the shipping defaults at startup via
 `load_state_check_backend("jsonpath")` + `load_state_check_backend("db_probes")`,
 and caches the resulting instances on `RunnerServiceImpl`. The check
 executor is threaded through the composite `grade_custom_checks`
-dispatch. The judge model provider is threaded into the
-`RubricEvaluatorContext` that the runner constructs at grade time —
-`load_rubric_evaluator("llm_judge")(ctx)` — and the composite
-`grade_llm_judge` receives the resolved evaluator; no LLM transport ever
-appears in composite. The transcript-rule matcher is threaded through the
+dispatch. The judge model provider and the resolved
+`load_judge_kind("single_shot_rubric")()` class are handed to the
+composite `grade_llm_judge` at grade time — the kind builds its own
+:class:`LLMJudge` per call from the caller's `ModelConfig` +
+customization (KB gate, custom system-prompt,
+include-agent-system-prompt); no LLM transport ever appears in
+composite. The transcript-rule matcher is threaded through the
 composite `grade_transcript_rules` dispatch; the events-less-trial gate
 (`scored_transcript_rules`) and the per-key accounting stay in the
 composite so every deployment topology applies them identically. The
@@ -676,20 +678,20 @@ routes those trials to a live-callback path in the caller.
 
 <a id="extension-points-the-nine-plug-in-groups"></a>
 
-## Extension points — the nine plug-in groups
+## Extension points — the ten plug-in groups
 
-Nine `importlib.metadata` entry-point groups let a downstream package
+Ten `importlib.metadata` entry-point groups let a downstream package
 extend the grader without a framework change: one runner-side dispatch
 selector (paired with the typed-kind registry), one substrate group, and
-six sub-component seams. Each group has a matching loader on
+seven sub-component seams. Each group has a matching loader on
 [`tolokaforge.core.plugin_registry`](../tolokaforge/core/plugin_registry.py):
 
 - `tolokaforge.grading_methods` — `load_grading_method(name)` returns the `GradingMethod` marker **class**. Names in this group are the values `RunnerGradingConfig.grading_method` accepts at `RegisterTrial`; the marker carries `NAME: ClassVar[str]` so a downstream typo in `pyproject.toml` fails at discovery. Every shipped name also registers in `tolokaforge.grader_kinds` below — `RegisterTrial` validates the wire name against both groups.
 - `tolokaforge.grader_kinds` — `load_grader_kind(name)` returns the typed `GraderKind` **class**, whose `evaluate(*, substrate, task_config, kind_config, trial_id, agent_tools, logger) -> Grade | None` drives runtime dispatch for every non-composite name at `RunnerServiceImpl._dispatch_via_grader_kind`. Composite (or `None`) stays on the runner-side fold. Two built-ins ship: `composite` (a reference impl over `CompositeFold`) and `test_execution` (reads through `substrate.run_test_suite(...)`).
+- `tolokaforge.judge_kinds` — `load_judge_kind(name)` returns the typed `JudgeKind` **class**, whose `evaluate(*, rubric, agent_system_prompt, transcript, db_reader, kb_search, workspace_dir, extra_read_tools, state_diff, judge_model_config, judge_model_provider, disable_knowledge_search, custom_system_prompt, include_agent_system_prompt, kind_config, logger) -> JudgeResult` drives runner-side LLM-judge dispatch. One built-in ships: `single_shot_rubric` (wraps `LLMJudge` byte-identically). Downstream kinds (chunked, agentic, jury) register alongside without a framework PR.
 - `tolokaforge.grading_substrates` — `load_grading_substrate(name)` returns the `GradingSubstrate` **class** (the caller instantiates it with per-trial arguments).
 - `tolokaforge.custom_check_executors` — `load_custom_check_executor(name)` returns a factory.
 - `tolokaforge.judge_model_providers` — `load_judge_model_provider(name)` returns a factory.
-- `tolokaforge.rubric_evaluators` — `load_rubric_evaluator(name)` returns a factory.
 - `tolokaforge.transcript_rule_matchers` — `load_transcript_rule_matcher(name)` returns a factory.
 - `tolokaforge.state_check_backends` — `load_state_check_backend(name)` returns a factory.
 - `tolokaforge.trace_check_operators` — `load_trace_check_operator(name)` returns the **operator callable** directly (no factory wrapper; the callable itself is the contract).
@@ -703,6 +705,9 @@ my_grading_method = "my_package:my_grading_method_marker"
 [project.entry-points."tolokaforge.grader_kinds"]
 my_grading_method = "my_package:MyGraderKind"
 
+[project.entry-points."tolokaforge.judge_kinds"]
+my_judge_kind = "my_package:MyJudgeKind"
+
 [project.entry-points."tolokaforge.grading_substrates"]
 my_substrate = "my_package:my_substrate_class"
 
@@ -711,9 +716,6 @@ my_check_executor = "my_package:my_check_executor_factory"
 
 [project.entry-points."tolokaforge.judge_model_providers"]
 my_judge = "my_package:my_judge_provider_factory"
-
-[project.entry-points."tolokaforge.rubric_evaluators"]
-my_rubric = "my_package:my_rubric_evaluator_factory"
 
 [project.entry-points."tolokaforge.transcript_rule_matchers"]
 my_matcher = "my_package:my_matcher_factory"

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -923,7 +923,7 @@ invariant.
 | `transcript_rules_only/` | `transcript_rule_matchers` | `transcript_rules` populated |
 | `trace_checks_heavy/` | `trace_check_operators` (bind + before + within) | `trace_checks.constraints` non-empty |
 | `custom_checks_only/` | `custom_check_executors` | `custom_checks.enabled: true` |
-| `rubric_only/` | `rubric_evaluators` + `judge_model_providers` | `llm_judge.rubric` populated |
+| `rubric_only/` | `judge_kinds` + `judge_model_providers` | `llm_judge.rubric` populated |
 
 The `state_checks_db_probes_only/` pack ships scripted probe rows on
 `parity.yaml`'s `db_probe_rows` field (keyed by probe name); the

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -293,7 +293,8 @@ entry, and carries every runner-reachable seam group verbatim from
 `pyproject.toml`: `tolokaforge.custom_check_executors`,
 `tolokaforge.judge_model_providers`, `tolokaforge.rubric_evaluators`,
 `tolokaforge.transcript_rule_matchers`, `tolokaforge.state_check_backends`,
-and `tolokaforge.trace_check_operators`. Without these, the runner boots
+`tolokaforge.trace_check_operators`, `tolokaforge.grading_methods`,
+`tolokaforge.grader_kinds`, and `tolokaforge.judge_kinds`. Without these, the runner boots
 then crashes at first seam load with "Unknown implementation …". The
 canonical enumeration lives at
 `scripts/hatch/hatch_runner_subset_builder.py::RUNNER_REACHABLE_ENTRY_POINT_GROUPS`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,18 @@ test_execution = "tolokaforge.core.grading.grading_method:TestExecutionGradingMe
 composite = "tolokaforge.core.grading.kinds.composite:CompositeGraderKind"
 test_execution = "tolokaforge.core.grading.kinds.test_execution:TestExecutionGraderKind"
 
+# Typed judge-kind Protocol registry. Every entry resolves to a class with a
+# kwargs-only ``evaluate(*, rubric, agent_system_prompt, transcript, db_reader,
+# kb_search, workspace_dir, extra_read_tools, state_diff, judge_model_config,
+# judge_model_provider, disable_knowledge_search, custom_system_prompt,
+# include_agent_system_prompt, kind_config, logger) -> JudgeResult``. The
+# runner-side composite dispatch resolves this loader to reach the LLM-judge
+# implementation registered as ``single_shot_rubric``; downstream packages
+# register alternative kinds (chunked, agentic, jury) alongside without a
+# framework PR. See :mod:`tolokaforge.core.grading.judge_kinds`.
+[project.entry-points."tolokaforge.judge_kinds"]
+single_shot_rubric = "tolokaforge.core.grading.judge_kinds.single_shot:SingleShotRubricJudgeKind"
+
 # ADR-0044 composition-plan adapter Protocols
 # (``tolokaforge/core/composition_runtime.py``). Each entry point resolves
 # directly to the impl class — the class is arg-less-constructible, so the

--- a/scripts/hatch/hatch_runner_subset_builder.py
+++ b/scripts/hatch/hatch_runner_subset_builder.py
@@ -82,6 +82,7 @@ RUNNER_REACHABLE_ENTRY_POINT_GROUPS: tuple[str, ...] = (
     "tolokaforge.trace_check_operators",
     "tolokaforge.grading_methods",
     "tolokaforge.grader_kinds",
+    "tolokaforge.judge_kinds",
 )
 
 

--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -34,6 +34,7 @@ from tolokaforge.core.grading.grading_method import (
     CompositeGradingMethod,
     TestExecutionGradingMethod,
 )
+from tolokaforge.core.grading.judge_kinds import SingleShotRubricJudgeKind
 from tolokaforge.core.grading.kinds import CompositeGraderKind, TestExecutionGraderKind
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.plugin_registry import (
@@ -41,6 +42,7 @@ from tolokaforge.core.plugin_registry import (
     COMPOSE_MATERIALISERS_GROUP,
     GRADER_KINDS_GROUP,
     GRADING_METHODS_GROUP,
+    JUDGE_KINDS_GROUP,
     RUNTIME_BACKENDS_GROUP,
     SERVICE_LIFECYCLE_DISPATCHERS_GROUP,
     SERVICE_READINESS_PROBES_GROUP,
@@ -55,6 +57,7 @@ from tolokaforge.core.plugin_registry import (
     available_conductors,
     available_grader_kinds,
     available_grading_methods,
+    available_judge_kinds,
     available_readiness_probes,
     available_runtime_backends,
     available_service_lifecycle_dispatchers,
@@ -66,6 +69,7 @@ from tolokaforge.core.plugin_registry import (
     load_conductor,
     load_grader_kind,
     load_grading_method,
+    load_judge_kind,
     load_readiness_probe,
     load_runtime_backend,
     load_service_lifecycle_dispatcher,
@@ -211,6 +215,18 @@ def test_grader_kind_names_resolve_to_their_class(name: str, expected_cls: type)
 @pytest.mark.parametrize(
     ("name", "expected_cls"),
     [
+        ("single_shot_rubric", SingleShotRubricJudgeKind),
+    ],
+)
+def test_judge_kind_names_resolve_to_their_class(name: str, expected_cls: type) -> None:
+    kind_cls = load_judge_kind(name)
+    assert kind_cls is expected_cls
+    assert name == kind_cls.NAME
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_cls"),
+    [
         ("local_disk", LocalDiskBundleStore),
         ("s3", S3BundleStore),
     ],
@@ -227,6 +243,7 @@ def test_available_listings_match_the_builtin_set() -> None:
     assert available_turn_policies() == ["agent_only", "conversational"]
     assert available_grading_methods() == ["composite", "test_execution"]
     assert available_grader_kinds() == ["composite", "test_execution"]
+    assert available_judge_kinds() == ["single_shot_rubric"]
     assert available_bundle_stores() == ["local_disk", "s3"]
     assert available_compose_materialisers() == ["docker_compose"]
     assert available_service_lifecycle_dispatchers() == ["ephemeral", "reset", "shared"]
@@ -258,6 +275,11 @@ def test_raw_entry_point_probe_lists_grading_methods() -> None:
 def test_raw_entry_point_probe_lists_grader_kinds() -> None:
     names = sorted(ep.name for ep in importlib.metadata.entry_points(group=GRADER_KINDS_GROUP))
     assert names == ["composite", "test_execution"]
+
+
+def test_raw_entry_point_probe_lists_judge_kinds() -> None:
+    names = sorted(ep.name for ep in importlib.metadata.entry_points(group=JUDGE_KINDS_GROUP))
+    assert names == ["single_shot_rubric"]
 
 
 def test_raw_entry_point_probe_lists_bundle_stores() -> None:

--- a/tests/canonical/test_grading_composite_llm_judge.py
+++ b/tests/canonical/test_grading_composite_llm_judge.py
@@ -1,23 +1,29 @@
 """``composite.grade_llm_judge`` — end-to-end judge dispatch parity lock.
 
-The composite delegates to a resolved :class:`RubricEvaluator` seam; the
-reference impl (``llm_judge``, :class:`LLMJudgeRubricEvaluator`) constructs
-an :class:`LLMJudge` per :meth:`.evaluate` and drives it. The runner path
-resolves the evaluator + renders the ``initial → final`` state diff and
-hands both to the composite via ``run_in_executor``. This suite constructs
-an :class:`InProcessGradingSubstrate` over a hand-built ``{initial_tables,
-final_tables, filesystem_root, kb_search, db_reader}`` fixture, drives
-:func:`composite.grade_llm_judge` with a scripted ``LLMClient`` (so the loop
-is deterministic), and asserts that the ``JudgeResult`` carries the same
-status, score, and per-criterion verdicts the judge would report against
-the same evidence.
+The composite deconstructs the substrate reads and delegates to a
+resolved :class:`JudgeKind` seam; the reference impl
+(``single_shot_rubric``, :class:`SingleShotRubricJudgeKind`) constructs
+an :class:`LLMJudge` per :meth:`.evaluate` and drives it. The runner
+path resolves the kind + renders the ``initial → final`` state diff
+and hands both to the composite via ``run_in_executor``. This suite
+constructs an :class:`InProcessGradingSubstrate` over a hand-built
+``{initial_tables, final_tables, filesystem_root, kb_search, db_reader}``
+fixture, drives :func:`composite.grade_llm_judge` with a scripted
+``LLMClient`` (so the loop is deterministic), and asserts that the
+``JudgeResult`` carries the same status, score, and per-criterion
+verdicts the judge would report against the same evidence.
 
-The scripted client is injected by monkeypatching ``LLMClient`` where
-:class:`LLMJudge` imports it — ``LLMJudge`` builds its own client per
-:meth:`run` via ``LLMClient(model_config)`` when its
-``llm_client`` kwarg is ``None``, and we override that constructor to return
-a queued script instead. The judge orchestration under test is the composite's
-call site + Protocol dispatch, not the LLM.
+The scripted client is injected via a scripted
+:class:`JudgeModelProvider` — the kind builds its own judge client per
+:meth:`.evaluate` via ``judge_model_provider.build(judge_model_config)``,
+and the scripted provider returns the queued script. The judge
+orchestration under test is the composite's call site + Protocol
+dispatch to the resolved kind, not the LLM.
+
+This suite exercises the **live** ``load_judge_kind("single_shot_rubric")``
+resolution — the entry-point group ``tolokaforge.judge_kinds`` is
+registered in ``pyproject.toml``, so a regression on the seam wire
+between the composite and the resolved kind fails these tests first.
 """
 
 from __future__ import annotations
@@ -28,15 +34,15 @@ from unittest.mock import MagicMock
 import pytest
 
 from tolokaforge.core.grading import composite
-from tolokaforge.core.grading.default_rubric_evaluator import LLMJudgeRubricEvaluator
+from tolokaforge.core.grading.judge_kinds import JudgeKind
 from tolokaforge.core.grading.judge_result import JudgeStatus
-from tolokaforge.core.grading.rubric_evaluator import RubricEvaluator
 from tolokaforge.core.grading.state_diff import render_state_diff
 from tolokaforge.core.grading.substrate import InProcessGradingSubstrate
 from tolokaforge.core.llm.client import GenerationResult
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.logging import StructuredLogger
 from tolokaforge.core.models import ModelConfig, ToolCall
+from tolokaforge.core.plugin_registry import load_judge_kind
 from tolokaforge.runner.models import (
     Criterion,
     LLMJudgeConfig,
@@ -102,33 +108,15 @@ class _ScriptedJudgeModelProvider:
         return self._client
 
 
-def _rubric_evaluator(
-    script: list[Any], config: LLMJudgeConfig | None = None
-) -> tuple[RubricEvaluator, _ScriptedClient]:
-    """Build the reference :class:`LLMJudgeRubricEvaluator` with the effective
-    customization flags a run-config would apply — matches the runner's
-    ``_grade_llm_judge`` construction one-for-one.
-
-    The evaluator's :class:`JudgeModelProvider` returns the scripted client
-    directly so the judge loop is deterministic — the shipped ``litellm``
-    transport never runs in the canonical path.
-    """
-    customization = config.customization if config is not None else None
-    disable_knowledge_search = bool(customization and customization.disable_knowledge_search)
-    custom_system_prompt = customization.system_prompt if customization else None
-    include_agent_system_prompt = (
-        customization.include_agent_system_prompt
-        if customization and customization.include_agent_system_prompt is not None
-        else True
-    )
+def _judge_kind_and_provider(
+    script: list[Any],
+) -> tuple[JudgeKind, _ScriptedJudgeModelProvider, _ScriptedClient]:
+    """Resolve the shipped ``single_shot_rubric`` kind + a scripted provider
+    (fresh scripted client each call so tests do not share loop state)."""
     client = _ScriptedClient(script)
-    evaluator = LLMJudgeRubricEvaluator(
-        _ScriptedJudgeModelProvider(client),
-        disable_knowledge_search=disable_knowledge_search,
-        custom_system_prompt=custom_system_prompt,
-        include_agent_system_prompt=include_agent_system_prompt,
-    )
-    return evaluator, client
+    provider = _ScriptedJudgeModelProvider(client)
+    kind = load_judge_kind("single_shot_rubric")()
+    return kind, provider, client
 
 
 def _render_diff(
@@ -207,33 +195,59 @@ def _logger() -> StructuredLogger:
     return StructuredLogger(name="test-composite-grade-llm-judge")
 
 
+def _drive_grade_llm_judge(
+    *,
+    config: LLMJudgeConfig,
+    substrate: InProcessGradingSubstrate,
+    llm_messages: list[dict[str, Any]],
+    state_diff: str | None,
+    script: list[Any],
+    disable_knowledge_search: bool = False,
+    custom_system_prompt: str | None = None,
+    include_agent_system_prompt: bool = True,
+):
+    """Drive :func:`composite.grade_llm_judge` through the live
+    ``load_judge_kind("single_shot_rubric")`` path with a scripted
+    judge model provider."""
+    kind, provider, _client = _judge_kind_and_provider(script)
+    return composite.grade_llm_judge(
+        trial_id="task:0",
+        config=config,
+        substrate=substrate,
+        judge_kind=kind,
+        judge_model_provider=provider,
+        disable_knowledge_search=disable_knowledge_search,
+        custom_system_prompt=custom_system_prompt,
+        include_agent_system_prompt=include_agent_system_prompt,
+        kind_config=None,
+        llm_messages=llm_messages,
+        judge_model_config=_JUDGE_MODEL,
+        extra_read_tools=[],
+        state_diff=state_diff,
+        logger=_logger(),
+    )
+
+
 class TestGradeLlmJudgeVerdicts:
-    """Every ``JudgeResult`` the composite produces is the same status,
-    score, and per-criterion verdicts the judge would report against the
-    same evidence."""
+    """Every ``JudgeResult`` the composite produces via
+    ``load_judge_kind("single_shot_rubric")`` is the same status, score,
+    and per-criterion verdicts the judge would report against the same
+    evidence."""
 
     def test_completed_run_returns_scored_criterion_results(self) -> None:
         config = LLMJudgeConfig(rubric=_rubric())
         substrate = _substrate()
-        evaluator, _ = _rubric_evaluator(
-            [[("submit_report", _submit_args(refund_done=True, tone=1.0))]],
-            config,
-        )
 
-        result = composite.grade_llm_judge(
-            trial_id="task:0",
+        result = _drive_grade_llm_judge(
             config=config,
             substrate=substrate,
-            rubric_evaluator=evaluator,
             llm_messages=[
                 {"role": "system", "content": "you are a refund agent"},
                 {"role": "user", "content": "please refund me"},
                 {"role": "assistant", "content": "refund processed"},
             ],
-            judge_model_config=_JUDGE_MODEL,
-            extra_read_tools=[],
             state_diff=_render_diff(substrate, []),
-            logger=_logger(),
+            script=[[("submit_report", _submit_args(refund_done=True, tone=1.0))]],
         )
 
         assert result.status is JudgeStatus.COMPLETED
@@ -256,24 +270,16 @@ class TestGradeLlmJudgeVerdicts:
                 primary_key="id",
             )
         ]
-        evaluator, _ = _rubric_evaluator(
-            [[("submit_report", _submit_args(refund_done=True, tone=1.0))]],
-            config,
-        )
 
-        result = composite.grade_llm_judge(
-            trial_id="task:0",
+        result = _drive_grade_llm_judge(
             config=config,
             substrate=substrate,
-            rubric_evaluator=evaluator,
             llm_messages=[
                 {"role": "system", "content": "policy"},
                 {"role": "user", "content": "please refund me"},
             ],
-            judge_model_config=_JUDGE_MODEL,
-            extra_read_tools=[],
             state_diff=_render_diff(substrate, schemas),
-            logger=_logger(),
+            script=[[("submit_report", _submit_args(refund_done=True, tone=1.0))]],
         )
         assert result.status is JudgeStatus.COMPLETED
         assert result.state_diff is not None
@@ -283,24 +289,16 @@ class TestGradeLlmJudgeVerdicts:
     def test_no_initial_state_yields_no_state_diff(self) -> None:
         config = LLMJudgeConfig(rubric=_rubric())
         substrate = _substrate()
-        evaluator, _ = _rubric_evaluator(
-            [[("submit_report", _submit_args(refund_done=False, tone=0.4))]],
-            config,
-        )
 
-        result = composite.grade_llm_judge(
-            trial_id="task:0",
+        result = _drive_grade_llm_judge(
             config=config,
             substrate=substrate,
-            rubric_evaluator=evaluator,
             llm_messages=[
                 {"role": "system", "content": "policy"},
                 {"role": "user", "content": "hi"},
             ],
-            judge_model_config=_JUDGE_MODEL,
-            extra_read_tools=[],
             state_diff=_render_diff(substrate, []),
-            logger=_logger(),
+            script=[[("submit_report", _submit_args(refund_done=False, tone=0.4))]],
         )
         assert result.status is JudgeStatus.COMPLETED
         assert result.state_diff is None
@@ -314,21 +312,16 @@ class TestGradeLlmJudgeVerdicts:
         composite preserves from the runner."""
         config = LLMJudgeConfig(rubric=_rubric())
         substrate = _substrate()
-        evaluator, _ = _rubric_evaluator(["turn one, no tool call"] * 20, config)
 
-        result = composite.grade_llm_judge(
-            trial_id="task:0",
+        result = _drive_grade_llm_judge(
             config=config,
             substrate=substrate,
-            rubric_evaluator=evaluator,
             llm_messages=[
                 {"role": "system", "content": "policy"},
                 {"role": "user", "content": "hi"},
             ],
-            judge_model_config=_JUDGE_MODEL,
-            extra_read_tools=[],
             state_diff=_render_diff(substrate, []),
-            logger=_logger(),
+            script=["turn one, no tool call"] * 20,
         )
         assert result.status is JudgeStatus.ERRORED
         assert result.score is None

--- a/tests/canonical/test_grading_rubric_evaluator_dispatch.py
+++ b/tests/canonical/test_grading_rubric_evaluator_dispatch.py
@@ -1,6 +1,6 @@
-"""``load_rubric_evaluator`` discovery + composite dispatch through the seam.
+"""``load_rubric_evaluator`` discovery + third-party evaluator driveability.
 
-Locks two seams the :class:`RubricEvaluator` design commits to:
+Locks two invariants the :class:`RubricEvaluator` seam commits to:
 
 1. :func:`~tolokaforge.core.plugin_registry.load_rubric_evaluator` resolves
    an evaluator registered via ``importlib.metadata`` entry-points. The
@@ -10,11 +10,14 @@ Locks two seams the :class:`RubricEvaluator` design commits to:
    deterministic factory. No wheel pollution: the demo stays discoverable
    only under the monkeypatched mapping.
 
-2. **Composite dispatch through the Protocol.**
-   :func:`composite.grade_llm_judge` drives the resolved evaluator and
-   its ``JudgeResult.score`` matches the deterministic hash the demo
-   emits — proving the composite reaches the plug-in evaluator without
-   ever touching :class:`LLMJudge`.
+2. **Third-party evaluator drives its own ``evaluate`` directly.** The
+   composite's LLM-judge dispatch routes through the newer
+   ``tolokaforge.judge_kinds`` seam, so a downstream integration that
+   still registers under ``tolokaforge.rubric_evaluators`` calls
+   ``.evaluate(...)`` on its resolved evaluator itself. Its
+   :class:`JudgeResult.score` matches the deterministic hash the demo
+   emits — proving the group is still resolvable and its resolved
+   evaluator still drives correctly.
 """
 
 from __future__ import annotations
@@ -31,7 +34,6 @@ from tests.utils.rubric_evaluator_demo import (
     _rubric_signature,
     _test_rubric_evaluator_factory,
 )
-from tolokaforge.core.grading import composite
 from tolokaforge.core.grading.judge_result import JudgeStatus
 from tolokaforge.core.grading.substrate import InProcessGradingSubstrate
 from tolokaforge.core.logging import StructuredLogger
@@ -138,12 +140,14 @@ def test_loader_resolves_the_monkeypatched_demo_evaluator(
         _clear_discovery_cache()
 
 
-def test_composite_dispatches_through_the_resolved_demo_evaluator(
+def test_resolved_demo_evaluator_drives_evaluate_directly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Composite's ``grade_llm_judge`` produces a :class:`JudgeResult`
-    whose score is the deterministic hash the demo emits — end-to-end
-    proof the seam threads the resolved evaluator through the dispatch.
+    """The resolved third-party evaluator drives its own ``.evaluate(...)``
+    against the substrate + rubric + evidence, and its
+    :class:`JudgeResult.score` matches the deterministic hash the demo
+    emits — proving the ``tolokaforge.rubric_evaluators`` group is still
+    resolvable and its resolved evaluator still drives correctly.
     """
     _inject_demo_evaluator(monkeypatch)
     try:
@@ -151,19 +155,16 @@ def test_composite_dispatches_through_the_resolved_demo_evaluator(
         config = LLMJudgeConfig(rubric=rubric)
         evaluator = load_rubric_evaluator("test_rubric_evaluator")(MagicMock())
 
-        result = composite.grade_llm_judge(
-            trial_id="task:0",
-            config=config,
-            substrate=_substrate(),
-            rubric_evaluator=evaluator,
-            llm_messages=[
-                {"role": "system", "content": "policy"},
+        result = evaluator.evaluate(
+            rubric=config.rubric,
+            agent_system_prompt="policy",
+            transcript=[
                 {"role": "user", "content": "please refund me"},
             ],
+            substrate=_substrate(),
             judge_model_config=_JUDGE_MODEL,
             extra_read_tools=[],
             state_diff=None,
-            logger=_logger(),
         )
 
         expected_score = _hash_to_score(_rubric_signature(rubric))

--- a/tests/canonical/test_grading_substrate_dispatch.py
+++ b/tests/canonical/test_grading_substrate_dispatch.py
@@ -56,7 +56,6 @@ from tolokaforge.core.grading.composite_fold import (
 from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS, CompositeGradeComponents
 from tolokaforge.core.grading.judge_result import JudgeStatus
 from tolokaforge.core.grading.key_manifest import EVALUATED
-from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
 from tolokaforge.core.grading.state_diff import render_state_diff
 from tolokaforge.core.grading.substrate_live import LiveRunnerCallbackGradingSubstrate
 from tolokaforge.core.grading.trace_checks import TraceChecksResult
@@ -69,7 +68,7 @@ from tolokaforge.core.plugin_registry import (
     GRADING_SUBSTRATES_GROUP,
     _clear_discovery_cache,
     load_grading_substrate,
-    load_rubric_evaluator,
+    load_judge_kind,
     load_state_check_backend,
     load_transcript_rule_matcher,
 )
@@ -442,12 +441,7 @@ def _reassemble_grade_from_composite(
         judge_reasons: str | None = None
         judge_gate_failed = False
         judge_report: pb2.JudgeReport | None = None
-        rubric_evaluator = load_rubric_evaluator("llm_judge")(
-            RubricEvaluatorContext(
-                judge_model_provider=runner._judge_model_provider,
-                logger=logger,  # type: ignore[arg-type]
-            )
-        )
+        judge_kind = load_judge_kind("single_shot_rubric")()
         initial_tables = substrate.initial_state()
         state_diff_text: str | None = None
         if initial_tables:
@@ -464,7 +458,12 @@ def _reassemble_grade_from_composite(
             trial_id=_TRIAL_ID,
             config=grading_config.llm_judge,
             substrate=substrate,
-            rubric_evaluator=rubric_evaluator,
+            judge_kind=judge_kind,
+            judge_model_provider=runner._judge_model_provider,
+            disable_knowledge_search=False,
+            custom_system_prompt=None,
+            include_agent_system_prompt=True,
+            kind_config=None,
             llm_messages=llm_messages,
             judge_model_config=_JUDGE_MODEL,
             extra_read_tools=[],

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -3678,8 +3678,10 @@ def _drive_llm_judge(
     red on claim 2 for a reason with nothing to do with the recording site.
     """
     from tolokaforge.core.grading import default_rubric_evaluator
+    from tolokaforge.core.grading.judge_kinds import single_shot as _judge_kind_single_shot
 
     monkeypatch.setattr(default_rubric_evaluator, "LLMJudge", _StubJudge)
+    monkeypatch.setattr(_judge_kind_single_shot, "LLMJudge", _StubJudge)
     task_description = runner_models.TaskDescription.model_validate(_JUDGE_DRIVER_TASK)
     _register_pack(
         servicer,

--- a/tests/canonical/test_judge_kind_single_shot_byte_parity.py
+++ b/tests/canonical/test_judge_kind_single_shot_byte_parity.py
@@ -1,0 +1,237 @@
+"""``SingleShotRubricJudgeKind`` — byte-parity with :class:`LLMJudgeRubricEvaluator`.
+
+Drives one fixture's inputs through:
+
+(a) the pre-seam :class:`LLMJudgeRubricEvaluator` path (kept alive by the
+    still-registered ``tolokaforge.rubric_evaluators`` group), and
+(b) the new ``load_judge_kind("single_shot_rubric")()`` path.
+
+Asserts both :class:`JudgeResult` instances match field-by-field on the
+same seed + same scripted judge model. Locks the "no observable
+behaviour change" contract Phase A1 commits to.
+
+**State-sharing warning:** ``_ScriptedClient._i`` advances on each
+``.generate()`` and ``_ScriptedJudgeModelProvider.build()`` caches its
+client, so the two legs MUST NOT share one provider instance — this
+suite builds a fresh ``_ScriptedClient`` (seeded from the same script
+list) and a fresh ``_ScriptedJudgeModelProvider(client)`` for each leg,
+otherwise the second leg reads exhausted-script output and byte-parity
+is spuriously violated.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.grading.default_rubric_evaluator import LLMJudgeRubricEvaluator
+from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus
+from tolokaforge.core.grading.substrate import InProcessGradingSubstrate
+from tolokaforge.core.llm.client import GenerationResult
+from tolokaforge.core.llm.usage import Usage
+from tolokaforge.core.logging import StructuredLogger
+from tolokaforge.core.models import ModelConfig, ToolCall
+from tolokaforge.core.plugin_registry import load_judge_kind
+from tolokaforge.runner.models import (
+    Criterion,
+    LLMJudgeConfig,
+    Rubric,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+_JUDGE_MODEL = ModelConfig(provider="openai", name="gpt-4o-mini", temperature=0.0)
+
+
+class _ScriptedClient:
+    """A scripted ``LoopLLMClient``: returns queued ``GenerationResult`` in order.
+
+    Each script entry is either a list of ``(tool_name, arguments)`` tuples
+    (emitted as tool calls) or a plain string (assistant text, no tool calls).
+    """
+
+    def __init__(self, script: list[Any]) -> None:
+        self._script = list(script)
+        self._i = 0
+
+    def generate(
+        self, system, messages, tools, tool_choice="auto", observation=None
+    ) -> GenerationResult:
+        if self._i >= len(self._script):
+            return GenerationResult(text="(exhausted)", tool_calls=[], usage=Usage())
+        step = self._script[self._i]
+        self._i += 1
+        if isinstance(step, str):
+            return GenerationResult(text=step, tool_calls=[], usage=Usage())
+        tool_calls = [
+            ToolCall(id=f"call_{self._i}_{j}", name=name, arguments=args)
+            for j, (name, args) in enumerate(step)
+        ]
+        return GenerationResult(
+            text="",
+            tool_calls=tool_calls,
+            usage=Usage(prompt_tokens=10, completion_tokens=5),
+            cost_usd=0.001,
+        )
+
+    def classify_loop_error(self, exc: Exception):
+        from tolokaforge.core.loop import classify_loop_error
+
+        return classify_loop_error(exc, ())
+
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
+
+
+class _ScriptedJudgeModelProvider:
+    """Test :class:`JudgeModelProvider` — returns a preloaded scripted client
+    as the ``JudgeModel``. Bypasses the shipped ``litellm`` transport so the
+    canonical suite drives the judge loop deterministically."""
+
+    def __init__(self, client: _ScriptedClient) -> None:
+        self._client = client
+
+    def build(self, model_config: ModelConfig):
+        return self._client
+
+
+def _rubric() -> Rubric:
+    """Two non-required criteria (binary weight 2.0 + graded weight 1.0)."""
+    return Rubric(
+        criteria=[
+            Criterion(
+                id="refund_done",
+                description="Refund issued",
+                kind="binary",
+                weight=2.0,
+            ),
+            Criterion(
+                id="tone",
+                description="Polite tone",
+                kind="graded",
+                weight=1.0,
+            ),
+        ]
+    )
+
+
+def _submit_args(**criteria: Any) -> dict[str, Any]:
+    """Build a well-formed ``submit_report`` payload from ``{id: verdict}``."""
+    args: dict[str, Any] = {"reasons": "overall summary"}
+    for cid, verdict in criteria.items():
+        args[cid] = verdict
+        if isinstance(verdict, bool):
+            marker = "VERDICT: MET" if verdict else "VERDICT: NOT MET"
+        else:
+            marker = f"SCORE: {verdict}"
+        args[f"{cid}_justification"] = f"because {cid}\n{marker}"
+    return args
+
+
+def _substrate() -> InProcessGradingSubstrate:
+    """Substrate exposing the reads the judge touches: DB reader seam
+    (the judge's read-only tools bridge to it); no KB, no filesystem."""
+    return InProcessGradingSubstrate(
+        db_reader=MagicMock(),
+        knowledge_search=None,
+        filesystem_root=None,
+        initial_state={},
+        final_state={},
+    )
+
+
+def _logger() -> StructuredLogger:
+    return StructuredLogger(name="test-judge-kind-byte-parity")
+
+
+def _script() -> list[Any]:
+    """One-turn submit_report: refund_done=True, tone=1.0."""
+    return [[("submit_report", _submit_args(refund_done=True, tone=1.0))]]
+
+
+def _run_pre_seam(config: LLMJudgeConfig) -> JudgeResult:
+    """Pre-seam path: :class:`LLMJudgeRubricEvaluator` (still registered
+    under ``tolokaforge.rubric_evaluators`` — the group is intentionally
+    left alive at Phase A1 to keep this parity check available)."""
+    client = _ScriptedClient(_script())
+    evaluator = LLMJudgeRubricEvaluator(
+        _ScriptedJudgeModelProvider(client),
+        disable_knowledge_search=False,
+        custom_system_prompt=None,
+        include_agent_system_prompt=True,
+        logger=_logger(),
+    )
+    return evaluator.evaluate(
+        rubric=config.rubric,
+        agent_system_prompt="you are a refund agent",
+        transcript=[
+            {"role": "user", "content": "please refund me"},
+            {"role": "assistant", "content": "refund processed"},
+        ],
+        substrate=_substrate(),
+        judge_model_config=_JUDGE_MODEL,
+        extra_read_tools=[],
+        state_diff=None,
+    )
+
+
+def _run_new_seam(config: LLMJudgeConfig) -> JudgeResult:
+    """New seam: ``load_judge_kind("single_shot_rubric")()`` — the
+    :class:`SingleShotRubricJudgeKind` wraps the same
+    :class:`LLMJudge` construction the pre-seam path uses. A fresh
+    ``_ScriptedClient`` is required so ``.generate()`` starts from
+    script index 0 on this leg — see module docstring."""
+    client = _ScriptedClient(_script())
+    kind = load_judge_kind("single_shot_rubric")()
+    substrate = _substrate()
+    return kind.evaluate(
+        rubric=config.rubric,
+        agent_system_prompt="you are a refund agent",
+        transcript=[
+            {"role": "user", "content": "please refund me"},
+            {"role": "assistant", "content": "refund processed"},
+        ],
+        db_reader=substrate.db_reader(),
+        kb_search=substrate.knowledge_search(),
+        workspace_dir=substrate.filesystem_root(),
+        extra_read_tools=[],
+        state_diff=None,
+        judge_model_config=_JUDGE_MODEL,
+        judge_model_provider=_ScriptedJudgeModelProvider(client),
+        disable_knowledge_search=False,
+        custom_system_prompt=None,
+        include_agent_system_prompt=True,
+        kind_config=None,
+        logger=_logger(),
+    )
+
+
+def test_single_shot_kind_matches_rubric_evaluator_field_by_field() -> None:
+    """The two legs produce field-identical :class:`JudgeResult` values
+    on the same rubric + scripted judge, proving the seam rewire changes
+    zero observable behaviour."""
+    config = LLMJudgeConfig(rubric=_rubric())
+    pre = _run_pre_seam(config)
+    new = _run_new_seam(config)
+
+    assert pre.status is JudgeStatus.COMPLETED
+    assert new.status is JudgeStatus.COMPLETED
+    assert pre.status == new.status
+    assert pre.score == new.score
+    assert pre.binary_pass == new.binary_pass
+    assert pre.gate_failed == new.gate_failed
+    assert pre.failed_required_ids == new.failed_required_ids
+    assert pre.reasons == new.reasons
+    assert pre.criterion_results == new.criterion_results
+    assert pre.kb_tools_offered == new.kb_tools_offered
+    assert pre.kb_tools_withheld == new.kb_tools_withheld
+    assert pre.knowledge_search_disabled == new.knowledge_search_disabled
+    assert pre.custom_system_prompt == new.custom_system_prompt
+    assert pre.include_agent_system_prompt == new.include_agent_system_prompt
+    assert pre.read_tools_offered == new.read_tools_offered
+    assert pre.state_diff == new.state_diff
+    assert pre.transcript == new.transcript
+    assert pre.usage == new.usage

--- a/tests/canonical/test_judge_kind_single_shot_byte_parity.py
+++ b/tests/canonical/test_judge_kind_single_shot_byte_parity.py
@@ -8,7 +8,7 @@ Drives one fixture's inputs through:
 
 Asserts both :class:`JudgeResult` instances match field-by-field on the
 same seed + same scripted judge model. Locks the "no observable
-behaviour change" contract Phase A1 commits to.
+behaviour change" contract this seam rewire commits to.
 
 **State-sharing warning:** ``_ScriptedClient._i`` advances on each
 ``.generate()`` and ``_ScriptedJudgeModelProvider.build()`` caches its
@@ -155,7 +155,7 @@ def _script() -> list[Any]:
 def _run_pre_seam(config: LLMJudgeConfig) -> JudgeResult:
     """Pre-seam path: :class:`LLMJudgeRubricEvaluator` (still registered
     under ``tolokaforge.rubric_evaluators`` — the group is intentionally
-    left alive at Phase A1 to keep this parity check available)."""
+    kept live so this parity check can drive both paths side by side)."""
     client = _ScriptedClient(_script())
     evaluator = LLMJudgeRubricEvaluator(
         _ScriptedJudgeModelProvider(client),

--- a/tests/canonical/test_judge_kinds_registry.py
+++ b/tests/canonical/test_judge_kinds_registry.py
@@ -1,0 +1,42 @@
+"""``tolokaforge.judge_kinds`` — resolver + Protocol satisfaction lock.
+
+Locks the three invariants the typed-kind registry commits to:
+
+1. The one built-in name (``single_shot_rubric``) resolves to
+   :class:`SingleShotRubricJudgeKind` with matching ``NAME``.
+2. An unknown name fails loud via :class:`UnknownImplementationError`
+   naming the offending key + the registered set + the group.
+3. The built-in class satisfies the runtime-checkable
+   :class:`JudgeKind` Protocol.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.grading.judge_kinds import JudgeKind, SingleShotRubricJudgeKind
+from tolokaforge.core.plugin_registry import (
+    UnknownImplementationError,
+    available_judge_kinds,
+    load_judge_kind,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+def test_builtin_judge_kind_resolves_to_its_class() -> None:
+    assert load_judge_kind("single_shot_rubric") is SingleShotRubricJudgeKind
+    assert available_judge_kinds() == ["single_shot_rubric"]
+
+
+def test_unknown_judge_kind_raises_named_error() -> None:
+    with pytest.raises(UnknownImplementationError) as exc_info:
+        load_judge_kind("does_not_exist")
+    message = str(exc_info.value)
+    assert "does_not_exist" in message
+    assert "tolokaforge.judge_kinds" in message
+    assert "single_shot_rubric" in message
+
+
+def test_judge_kind_class_is_runtime_checkable_protocol_instance() -> None:
+    assert isinstance(SingleShotRubricJudgeKind(), JudgeKind)

--- a/tests/canonical/test_judge_kinds_third_party_registration.py
+++ b/tests/canonical/test_judge_kinds_third_party_registration.py
@@ -1,0 +1,120 @@
+"""``tolokaforge.judge_kinds`` — third-party ``importlib.metadata`` registration lock.
+
+A downstream package registering a class under the
+``tolokaforge.judge_kinds`` entry-point group MUST resolve through
+:func:`load_judge_kind` without a framework PR. This test injects a
+fake :class:`JudgeKind` class into the discovery scan via
+``importlib.metadata.entry_points`` monkeypatching (mirrors
+:func:`test_rubric_evaluator` fixture pattern in
+:mod:`tests.canonical.test_grading_rubric_evaluator_dispatch`), then
+resolves it and dispatches ``.evaluate(...)``, asserting the sentinel
+:class:`JudgeResult` the fake kind emits.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import Any, ClassVar
+
+import pytest
+
+from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus, JudgeUsage
+from tolokaforge.core.plugin_registry import (
+    JUDGE_KINDS_GROUP,
+    _clear_discovery_cache,
+    load_judge_kind,
+)
+from tolokaforge.runner.models import Criterion, CriterionResult, Rubric
+
+pytestmark = pytest.mark.canonical
+
+
+class _FakeJudgeKind:
+    """Deterministic third-party judge kind for the registration test."""
+
+    NAME: ClassVar[str] = "test_judge_kind"
+
+    def evaluate(self, **kwargs: Any) -> JudgeResult:  # noqa: ARG002 — sentinel ignores every kwarg
+        return JudgeResult(
+            status=JudgeStatus.COMPLETED,
+            usage=JudgeUsage(),
+            reasons="third-party fake kind reached",
+            score=1.0,
+            criterion_results=(
+                CriterionResult(
+                    id="sentinel",
+                    met=True,
+                    score=1.0,
+                    justification="deterministic sentinel",
+                ),
+            ),
+        )
+
+
+class _EntryPointStub:
+    """Duck-typed ``importlib.metadata.EntryPoint`` for the discovery scan.
+
+    Enumerates ``name`` / ``dist`` and returns ``value`` on ``load()`` —
+    the surface :func:`discover_entry_points` reads.
+    """
+
+    def __init__(self, name: str, value: Any, dist_name: str = "tests-fixture") -> None:
+        self.name = name
+        self.value = value
+
+        class _Dist:
+            def __init__(self, dn: str) -> None:
+                self.name = dn
+
+        self.dist = _Dist(dist_name)
+
+    def load(self) -> Any:
+        return self.value
+
+
+def _inject_fake_judge_kind(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register the fake judge kind alongside the shipped ``single_shot_rubric``."""
+    _clear_discovery_cache()
+    shipped = list(importlib.metadata.entry_points(group=JUDGE_KINDS_GROUP))
+    injected = _EntryPointStub("test_judge_kind", _FakeJudgeKind)
+
+    def fake_entry_points(*, group: str) -> list[Any]:
+        if group == JUDGE_KINDS_GROUP:
+            return [*shipped, injected]
+        return list(importlib.metadata.entry_points(group=group))
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    _clear_discovery_cache()
+
+
+def test_third_party_judge_kind_registration_dispatches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _inject_fake_judge_kind(monkeypatch)
+    try:
+        cls = load_judge_kind("test_judge_kind")
+        assert cls is _FakeJudgeKind
+        result = cls().evaluate(
+            rubric=Rubric(
+                criteria=[Criterion(id="sentinel", description="anything", kind="binary")]
+            ),
+            agent_system_prompt="",
+            transcript=[],
+            db_reader=None,
+            kb_search=None,
+            workspace_dir=None,
+            extra_read_tools=[],
+            state_diff=None,
+            judge_model_config=None,
+            judge_model_provider=None,
+            disable_knowledge_search=False,
+            custom_system_prompt=None,
+            include_agent_system_prompt=True,
+            kind_config=None,
+            logger=None,
+        )
+        assert result.status is JudgeStatus.COMPLETED
+        assert result.reasons == "third-party fake kind reached"
+        assert [cr.id for cr in result.criterion_results] == ["sentinel"]
+    finally:
+        _clear_discovery_cache()

--- a/tests/canonical/test_runner_subset_partition.py
+++ b/tests/canonical/test_runner_subset_partition.py
@@ -655,6 +655,7 @@ _LOADER_TO_GROUP: dict[str, str] = {
     "load_grading_substrate": "tolokaforge.grading_substrates",
     "load_grading_method": "tolokaforge.grading_methods",
     "load_grader_kind": "tolokaforge.grader_kinds",
+    "load_judge_kind": "tolokaforge.judge_kinds",
 }
 
 

--- a/tests/unit/test_runner_judge_kb_gate.py
+++ b/tests/unit/test_runner_judge_kb_gate.py
@@ -424,7 +424,7 @@ def test_grade_llm_judge_constructs_with_effective_disable_flag(
                 status=JudgeStatus.COMPLETED, usage=JudgeUsage(), reasons="ok", score=1.0
             )
 
-    monkeypatch.setattr("tolokaforge.core.grading.default_rubric_evaluator.LLMJudge", _SpyJudge)
+    monkeypatch.setattr("tolokaforge.core.grading.judge_kinds.single_shot.LLMJudge", _SpyJudge)
 
     service = _service(None)
     try:
@@ -476,7 +476,7 @@ def test_grade_llm_judge_constructs_with_effective_custom_prompt(
                 status=JudgeStatus.COMPLETED, usage=JudgeUsage(), reasons="ok", score=1.0
             )
 
-    monkeypatch.setattr("tolokaforge.core.grading.default_rubric_evaluator.LLMJudge", _SpyJudge)
+    monkeypatch.setattr("tolokaforge.core.grading.judge_kinds.single_shot.LLMJudge", _SpyJudge)
 
     service = _service(None)
     try:
@@ -531,7 +531,7 @@ def test_grade_llm_judge_constructs_with_effective_include_agent_system_prompt(
                 status=JudgeStatus.COMPLETED, usage=JudgeUsage(), reasons="ok", score=1.0
             )
 
-    monkeypatch.setattr("tolokaforge.core.grading.default_rubric_evaluator.LLMJudge", _SpyJudge)
+    monkeypatch.setattr("tolokaforge.core.grading.judge_kinds.single_shot.LLMJudge", _SpyJudge)
 
     service = _service(None)
     try:
@@ -590,7 +590,7 @@ def test_grade_trial_populates_judge_report_kb_gating(monkeypatch):
                 include_agent_system_prompt=False,
             )
 
-    monkeypatch.setattr("tolokaforge.core.grading.default_rubric_evaluator.LLMJudge", _SpyJudge)
+    monkeypatch.setattr("tolokaforge.core.grading.judge_kinds.single_shot.LLMJudge", _SpyJudge)
 
     rubric = Rubric(criteria=[{"id": "a", "description": "d", "kind": "binary", "weight": 1.0}])
     task_desc = TaskDescription(

--- a/tolokaforge/core/grading/composite/llm_judge.py
+++ b/tolokaforge/core/grading/composite/llm_judge.py
@@ -8,6 +8,7 @@ BEFORE :func:`grade_llm_judge` to prepare the ``state_diff`` kwarg.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from tolokaforge.core.grading.judge_result import JudgeResult
@@ -16,8 +17,9 @@ from tolokaforge.core.grading.substrate import SubstrateUnreachableError
 from tolokaforge.core.grading.transcript_wire import split_leading_system_message
 
 if TYPE_CHECKING:
+    from tolokaforge.core.grading.judge_kinds import JudgeKind
+    from tolokaforge.core.grading.judge_model_provider import JudgeModelProvider
     from tolokaforge.core.grading.judge_tools import DelegatingReadTool
-    from tolokaforge.core.grading.rubric_evaluator import RubricEvaluator
     from tolokaforge.core.grading.substrate import GradingSubstrate
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.models import ModelConfig
@@ -26,10 +28,15 @@ if TYPE_CHECKING:
 
 def grade_llm_judge(
     *,
-    trial_id: str,
+    trial_id: str,  # noqa: ARG001 — kept for call-site parity + future per-trial logging
     config: LLMJudgeConfig,
     substrate: GradingSubstrate,
-    rubric_evaluator: RubricEvaluator,
+    judge_kind: JudgeKind,
+    judge_model_provider: JudgeModelProvider,
+    disable_knowledge_search: bool,
+    custom_system_prompt: str | None,
+    include_agent_system_prompt: bool,
+    kind_config: Mapping[str, Any] | None,
     llm_messages: list[dict[str, Any]],
     judge_model_config: ModelConfig,
     extra_read_tools: list[DelegatingReadTool],
@@ -38,50 +45,61 @@ def grade_llm_judge(
 ) -> JudgeResult:
     """Run the read-only rubric judge against ``substrate`` and return its verdict.
 
-    The evaluator reads through the substrate seam for all live evidence:
-    :meth:`substrate.db_reader` for the read-only DB tools it exposes,
-    :meth:`substrate.knowledge_search` for ``search_kb``, and
-    :meth:`substrate.filesystem_root` for ``read_file`` (``None`` withholds it).
-    ``state_diff`` is a runner-resolved passthrough — the caller renders the
-    ``initial → final`` DB delta and hands it in; the composite forwards it
-    verbatim.
+    Deconstructs the substrate reads into the per-trial evidence kwargs
+    :class:`JudgeKind.evaluate` takes — :meth:`substrate.db_reader` for
+    the read-only DB tools it exposes, :meth:`substrate.knowledge_search`
+    for ``search_kb``, and :meth:`substrate.filesystem_root` for
+    ``read_file`` (``None`` withholds it). ``state_diff`` is a
+    runner-resolved passthrough — the caller renders the
+    ``initial → final`` DB delta and hands it in; the composite forwards
+    it verbatim.
 
-    ``extra_read_tools`` is a runner-resolved passthrough: the caller reconstructs
-    the agent's ``search_policy`` connector as :class:`DelegatingReadTool` s so
-    the judge can reuse the SAME TypeSense connector the agent used. The composite
-    forwards ``extra_read_tools`` verbatim to the evaluator.
+    ``extra_read_tools`` is a runner-resolved passthrough: the caller
+    reconstructs the agent's ``search_policy`` connector as
+    :class:`DelegatingReadTool` s so the judge can reuse the SAME
+    TypeSense connector the agent used.
 
-    ``rubric_evaluator`` is the resolved :class:`RubricEvaluator` seam the
-    runner supplies — a plug-in impl (``llm_judge`` in the shipping config,
-    a downstream deterministic ruleset alongside) that owns the actual grade
-    dispatch. The trial's :attr:`LLMJudgeConfig.customization` (KB gate,
-    custom system-prompt, include-agent-system-prompt) is applied
-    construction-side on the evaluator instance itself — the composite only
-    forwards the per-trial evidence to :meth:`evaluator.evaluate`.
+    ``judge_kind`` is the resolved :class:`JudgeKind` seam the runner
+    supplies — a plug-in impl (``single_shot_rubric`` in the shipping
+    config, a downstream chunked / agentic / jury kind alongside) that
+    owns the actual grade dispatch. Per-trial customization (KB gate,
+    custom system-prompt, include-agent-system-prompt) rides alongside
+    on the ``evaluate`` kwargs — the composite forwards them so the kind
+    constructs the judge instance itself.
 
-    Fail-loud contract: any judge malfunction — malformed ``submit_report`` past
-    retries, budget/turn exhaustion, or a loop-terminal exception — surfaces as
-    :attr:`JudgeStatus.ERRORED` with ``score is None``. Never a 0.0 / 0.5
-    fallback. :class:`SubstrateUnreachableError` from a substrate read
-    propagates so the dispatch site can translate it to ``GradingFailedError``.
+    Fail-loud contract: any judge malfunction — malformed
+    ``submit_report`` past retries, budget/turn exhaustion, or a
+    loop-terminal exception — surfaces as :attr:`JudgeStatus.ERRORED`
+    with ``score is None``. Never a 0.0 / 0.5 fallback.
+    :class:`SubstrateUnreachableError` from a substrate read propagates
+    so the dispatch site can translate it to ``GradingFailedError``.
 
-    Sync-in-async note: the composite is a **sync** function. The InProcess
-    substrate's factories block on ``run_coroutine_threadsafe`` to bridge to
-    the runner's dedicated event-loop thread, which deadlocks when called
-    from that loop. The runner therefore dispatches this function via
-    ``loop.run_in_executor(None, ...)`` — matching the shipped
-    ``grade_state_checks_reads`` bridge — so the substrate's blocking reads
-    (and the evaluator's own DB reads) land off the loop thread.
+    Sync-in-async note: the composite is a **sync** function. The
+    InProcess substrate's factories block on ``run_coroutine_threadsafe``
+    to bridge to the runner's dedicated event-loop thread, which
+    deadlocks when called from that loop. The runner therefore
+    dispatches this function via ``loop.run_in_executor(None, ...)`` —
+    matching the shipped ``grade_state_checks_reads`` bridge — so the
+    substrate's blocking reads (and the kind's own DB reads) land off
+    the loop thread.
     """
     agent_system_prompt, transcript = split_leading_system_message(list(llm_messages))
-    return rubric_evaluator.evaluate(
+    return judge_kind.evaluate(
         rubric=config.rubric,
         agent_system_prompt=agent_system_prompt,
         transcript=transcript,
-        substrate=substrate,
-        judge_model_config=judge_model_config,
+        db_reader=substrate.db_reader(),
+        kb_search=substrate.knowledge_search(),
+        workspace_dir=substrate.filesystem_root(),
         extra_read_tools=list(extra_read_tools),
         state_diff=state_diff,
+        judge_model_config=judge_model_config,
+        judge_model_provider=judge_model_provider,
+        disable_knowledge_search=disable_knowledge_search,
+        custom_system_prompt=custom_system_prompt,
+        include_agent_system_prompt=include_agent_system_prompt,
+        kind_config=kind_config,
+        logger=logger,
     )
 
 

--- a/tolokaforge/core/grading/judge_kinds/__init__.py
+++ b/tolokaforge/core/grading/judge_kinds/__init__.py
@@ -1,0 +1,19 @@
+"""``tolokaforge.judge_kinds`` — typed judge-kind package.
+
+Every entry in ``[project.entry-points."tolokaforge.judge_kinds"]``
+resolves to a class satisfying :class:`JudgeKind`. One built-in ships:
+:class:`SingleShotRubricJudgeKind`, wrapping today's :class:`LLMJudge`
+invocation byte-identically.
+
+Downstream packages register alternative kinds (chunked, agentic, jury,
+downstream-specific) alongside the shipping reference impl without a
+framework PR — see ``docs/GRADER_SERVICE.md`` § Extension points.
+"""
+
+from tolokaforge.core.grading.judge_kinds._protocol import JudgeKind
+from tolokaforge.core.grading.judge_kinds.single_shot import SingleShotRubricJudgeKind
+
+__all__ = [
+    "JudgeKind",
+    "SingleShotRubricJudgeKind",
+]

--- a/tolokaforge/core/grading/judge_kinds/_protocol.py
+++ b/tolokaforge/core/grading/judge_kinds/_protocol.py
@@ -1,0 +1,78 @@
+"""``JudgeKind`` — typed judge-kind Protocol.
+
+Every entry registered under ``tolokaforge.judge_kinds`` resolves to a
+class satisfying :class:`JudgeKind`. The class carries a ``NAME`` matching
+its entry-point name (so a pyproject typo surfaces at discovery, not at
+judge time) and an ``evaluate`` method that produces a
+:class:`~tolokaforge.core.grading.judge_result.JudgeResult` from the
+per-trial rubric evidence.
+
+``evaluate`` is kwargs-only. Callers bind arguments at dispatch time so a
+future field lands mid-list without positional drift on downstream
+adapters. The signature mirrors :meth:`LLMJudge.run` verbatim on the
+per-trial evidence surface (``rubric`` + ``agent_system_prompt`` +
+``transcript`` + ``db_reader`` + ``kb_search`` + ``workspace_dir`` +
+``extra_read_tools`` + ``state_diff``) plus construction inputs the kind
+must have to build its own judge instance
+(``judge_model_config`` + ``judge_model_provider``), plus per-trial
+customization (``disable_knowledge_search`` + ``custom_system_prompt`` +
+``include_agent_system_prompt``) and a ``kind_config`` handle downstream
+kinds read from.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from tolokaforge.core.grading.judge import DBReader
+    from tolokaforge.core.grading.judge_model_provider import JudgeModelProvider
+    from tolokaforge.core.grading.judge_result import JudgeResult
+    from tolokaforge.core.grading.kb_search import KnowledgeSearch
+    from tolokaforge.core.logging import StructuredLogger
+    from tolokaforge.core.models import ModelConfig
+    from tolokaforge.runner.models import Rubric
+    from tolokaforge.tools.registry import Tool
+
+__all__ = [
+    "JudgeKind",
+]
+
+
+@runtime_checkable
+class JudgeKind(Protocol):
+    """Marker + evaluator Protocol every ``tolokaforge.judge_kinds`` entry resolves to.
+
+    ``NAME`` MUST equal the entry-point name so a downstream typo in
+    ``pyproject.toml`` surfaces at discovery, not at judge time.
+
+    ``evaluate`` produces a :class:`JudgeResult`; a judge malfunction
+    (malformed ``submit_report`` past retries, budget/turn exhaustion,
+    a loop-terminal exception) surfaces as
+    :attr:`JudgeStatus.ERRORED` with ``score is None`` — never a
+    ``0.0`` / ``0.5`` fallback.
+    """
+
+    NAME: ClassVar[str]
+
+    def evaluate(
+        self,
+        *,
+        rubric: Rubric,
+        agent_system_prompt: str,
+        transcript: list[dict[str, Any]],
+        db_reader: DBReader | None,
+        kb_search: KnowledgeSearch | None,
+        workspace_dir: Path | None,
+        extra_read_tools: list[Tool],
+        state_diff: str | None,
+        judge_model_config: ModelConfig,
+        judge_model_provider: JudgeModelProvider,
+        disable_knowledge_search: bool,
+        custom_system_prompt: str | None,
+        include_agent_system_prompt: bool,
+        kind_config: Mapping[str, Any] | None,
+        logger: StructuredLogger,
+    ) -> JudgeResult: ...

--- a/tolokaforge/core/grading/judge_kinds/single_shot.py
+++ b/tolokaforge/core/grading/judge_kinds/single_shot.py
@@ -1,0 +1,80 @@
+"""Reference impl of :class:`JudgeKind` — wraps :class:`LLMJudge` in one shot.
+
+Registered under the name ``single_shot_rubric`` in the
+``tolokaforge.judge_kinds`` entry-point group. Builds the judge model
+from the caller-supplied :class:`JudgeModelProvider`, constructs an
+:class:`LLMJudge` with the caller-supplied per-trial customization, and
+runs it once over the trial's rubric evidence.
+
+Byte-identity anchor: the ``LLMJudge`` construction below matches the
+pre-seam :class:`LLMJudgeRubricEvaluator.evaluate` call one-for-one, so
+:meth:`SingleShotRubricJudgeKind.evaluate` produces the same
+:class:`JudgeResult` the pre-seam path produced from the same inputs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from tolokaforge.core.grading.judge import LLMJudge
+
+if TYPE_CHECKING:
+    from tolokaforge.core.grading.judge import DBReader
+    from tolokaforge.core.grading.judge_model_provider import JudgeModelProvider
+    from tolokaforge.core.grading.judge_result import JudgeResult
+    from tolokaforge.core.grading.kb_search import KnowledgeSearch
+    from tolokaforge.core.logging import StructuredLogger
+    from tolokaforge.core.models import ModelConfig
+    from tolokaforge.runner.models import Rubric
+    from tolokaforge.tools.registry import Tool
+
+__all__ = [
+    "SingleShotRubricJudgeKind",
+]
+
+
+class SingleShotRubricJudgeKind:
+    """Grade one rubric with one :class:`LLMJudge` invocation."""
+
+    NAME: ClassVar[str] = "single_shot_rubric"
+
+    def evaluate(
+        self,
+        *,
+        rubric: Rubric,
+        agent_system_prompt: str,
+        transcript: list[dict[str, Any]],
+        db_reader: DBReader | None,
+        kb_search: KnowledgeSearch | None,
+        workspace_dir: Path | None,
+        extra_read_tools: list[Tool],
+        state_diff: str | None,
+        judge_model_config: ModelConfig,
+        judge_model_provider: JudgeModelProvider,
+        disable_knowledge_search: bool,
+        custom_system_prompt: str | None,
+        include_agent_system_prompt: bool,
+        kind_config: Mapping[str, Any] | None,
+        logger: StructuredLogger,
+    ) -> JudgeResult:
+        del kind_config  # reserved on the Protocol for downstream kinds; Phase A2 wires
+        judge_model = judge_model_provider.build(judge_model_config)
+        return LLMJudge(
+            judge_model_config,
+            disable_knowledge_search=disable_knowledge_search,
+            custom_system_prompt=custom_system_prompt,
+            include_agent_system_prompt=include_agent_system_prompt,
+            llm_client=judge_model,
+            logger=logger,
+        ).run(
+            rubric=rubric,
+            agent_system_prompt=agent_system_prompt,
+            transcript=transcript,
+            db_reader=db_reader,
+            kb_search=kb_search,
+            extra_read_tools=list(extra_read_tools),
+            workspace_dir=workspace_dir,
+            state_diff=state_diff,
+        )

--- a/tolokaforge/core/grading/judge_kinds/single_shot.py
+++ b/tolokaforge/core/grading/judge_kinds/single_shot.py
@@ -59,7 +59,7 @@ class SingleShotRubricJudgeKind:
         kind_config: Mapping[str, Any] | None,
         logger: StructuredLogger,
     ) -> JudgeResult:
-        del kind_config  # reserved on the Protocol for downstream kinds; Phase A2 wires
+        del kind_config  # reserved on the Protocol for downstream kinds
         judge_model = judge_model_provider.build(judge_model_config)
         return LLMJudge(
             judge_model_config,

--- a/tolokaforge/core/grading/judge_only_helpers.py
+++ b/tolokaforge/core/grading/judge_only_helpers.py
@@ -1,15 +1,15 @@
 """Pure helper the ``judge_only`` factory delegates its per-trial dispatch to.
 
-``run_judge_only_for_trajectory`` runs :class:`LLMJudge` against a trajectory
-with the constrained-input shape ``judge_only`` grades under — no
-``db_reader``, no ``kb_search``, no ``workspace_dir``, no ``state_diff``, no
-``extra_read_tools``. That constrained shape is the same one the
-runner-side composite path collapses to when a task declares
-``grading.grading_method = "composite"`` (or omits it) with
-``weights: {llm_judge: 1.0}`` and no state / transcript-rule / trace-check /
-custom-check / KB surface — so both paths route through this helper's
-:class:`LLMJudge` invocation with byte-identical inputs, and the parity
-gate at
+``run_judge_only_for_trajectory`` dispatches the ``single_shot_rubric``
+:class:`JudgeKind` against a trajectory with the constrained-input shape
+``judge_only`` grades under — no ``db_reader``, no ``kb_search``, no
+``workspace_dir``, no ``state_diff``, no ``extra_read_tools``. That
+constrained shape is the same one the runner-side composite path
+collapses to when a task declares ``grading.grading_method = "composite"``
+(or omits it) with ``weights: {llm_judge: 1.0}`` and no state /
+transcript-rule / trace-check / custom-check / KB surface — so both
+paths route through the same ``single_shot_rubric`` kind with
+byte-identical inputs, and the parity gate at
 ``tests/canonical/test_judge_only_composite_llm_judge_only_parity.py``
 locks that convergence.
 
@@ -28,15 +28,16 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
-from tolokaforge.core.grading.judge import LLMJudge
 from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
 from tolokaforge.core.grading.replay import build_replay_grade
 from tolokaforge.core.grading.transcript_wire import (
     encode_transcript_wire,
     split_leading_system_message,
 )
+from tolokaforge.core.plugin_registry import load_judge_kind, load_judge_model_provider
 
 if TYPE_CHECKING:
+    from tolokaforge.core.grading.judge_model_provider import JudgeModel, JudgeModelProvider
     from tolokaforge.core.llm.client import LLMClient
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.models import (
@@ -52,6 +53,26 @@ __all__ = [
 ]
 
 
+class _FixedClientJudgeModelProvider:
+    """Test-injection adapter: return the wrapped ``LLMClient`` verbatim.
+
+    The ``judge_only`` grader's test surface injects a pre-built
+    :class:`LLMClient` (canonical suites drive scripted models this
+    way). The :class:`JudgeKind` seam takes a
+    :class:`JudgeModelProvider` on ``evaluate``, so callers with a
+    fixed client wrap it here — the provider ignores ``ModelConfig``
+    and returns the wrapped client. Production callers construct
+    ``load_judge_model_provider("litellm")()`` instead.
+    """
+
+    def __init__(self, client: LLMClient) -> None:
+        self._client = client
+
+    def build(self, model_config: ModelConfig) -> JudgeModel:
+        del model_config  # fixed-client shim ignores per-call config
+        return self._client  # type: ignore[return-value]  # LLMClient structurally satisfies JudgeModel
+
+
 def run_judge_only_for_trajectory(
     *,
     trial_id: str,
@@ -63,7 +84,7 @@ def run_judge_only_for_trajectory(
     llm_client: LLMClient | None,
     logger: StructuredLogger,
 ) -> Grade | None:
-    """Run :class:`LLMJudge` over ``trajectory`` and return the persistable Grade.
+    """Run ``single_shot_rubric`` over ``trajectory`` and return the persistable Grade.
 
     Encodes the trajectory through the same
     :func:`encode_transcript_wire` + :func:`split_leading_system_message`
@@ -74,10 +95,11 @@ def run_judge_only_for_trajectory(
     per-field when the field is not ``None`` (see :class:`JudgeGraderConfig`
     — the override cannot express "reset to library default").
 
-    ``llm_client`` is a test-only injection point that lands on
-    :class:`LLMJudge`; production callers pass ``None`` and the judge
-    builds its own client. Fail-loud contract: an
-    :attr:`JudgeStatus.ERRORED` verdict raises
+    ``llm_client`` is a test-only injection point wrapped in
+    :class:`_FixedClientJudgeModelProvider` so the kind sees a
+    :class:`JudgeModelProvider`; production callers pass ``None`` and
+    the helper resolves ``load_judge_model_provider("litellm")()``.
+    Fail-loud contract: an :attr:`JudgeStatus.ERRORED` verdict raises
     :class:`~tolokaforge.core.trial_grader.GradingFailedError` — the
     trial is ungradeable rather than an agent failure. Only a
     ``COMPLETED`` verdict is translated through
@@ -110,20 +132,31 @@ def run_judge_only_for_trajectory(
         if override is not None and override.include_agent_system_prompt is not None
         else base_include_agent
     )
-    judge = LLMJudge(
-        judge_model_config,
+
+    judge_model_provider: JudgeModelProvider = (
+        _FixedClientJudgeModelProvider(llm_client)
+        if llm_client is not None
+        else load_judge_model_provider("litellm")()
+    )
+    judge_kind = load_judge_kind("single_shot_rubric")()
+    result = judge_kind.evaluate(
+        rubric=llm_judge_config.rubric,
+        agent_system_prompt=judge_agent_prompt,
+        transcript=transcript,
+        db_reader=None,
+        kb_search=None,
+        workspace_dir=None,
+        extra_read_tools=[],
+        state_diff=None,
+        judge_model_config=judge_model_config,
+        judge_model_provider=judge_model_provider,
         disable_knowledge_search=bool(disable_kb_resolved),
         custom_system_prompt=custom_prompt,
         include_agent_system_prompt=(
             include_agent_resolved if include_agent_resolved is not None else True
         ),
-        llm_client=llm_client,
+        kind_config=None,
         logger=logger,
-    )
-    result = judge.run(
-        rubric=llm_judge_config.rubric,
-        agent_system_prompt=judge_agent_prompt,
-        transcript=transcript,
     )
     if result.status is JudgeRunStatus.ERRORED:
         raise GradingFailedError(

--- a/tolokaforge/core/grading/kinds/composite.py
+++ b/tolokaforge/core/grading/kinds/composite.py
@@ -18,7 +18,7 @@ Two-mode dispatch:
    ``judge_model_config`` via the substrate accessors added in bundle
    format v1.1; loads the five shipped sub-component plug-ins
    (state_check_backends, transcript_rule_matcher,
-   custom_check_executor, judge_model_provider, rubric_evaluator);
+   custom_check_executor, judge_model_provider, judge_kind);
    drives ``composite.grade_state_checks_reads`` /
    ``grade_transcript_rules`` / ``grade_trace_checks`` /
    ``build_judge_state_diff`` + ``grade_llm_judge`` /
@@ -196,8 +196,8 @@ class CompositeGraderKind:
         from tolokaforge.core.models.trajectory import Trajectory as _Trajectory
         from tolokaforge.core.plugin_registry import (
             load_custom_check_executor,
+            load_judge_kind,
             load_judge_model_provider,
-            load_rubric_evaluator,
             load_state_check_backend,
             load_transcript_rule_matcher,
         )
@@ -309,7 +309,7 @@ class CompositeGraderKind:
                     logger=logger,
                     composite_mod=composite,
                     composite_components_cls=CompositeGradeComponents,
-                    load_rubric_evaluator=load_rubric_evaluator,
+                    load_judge_kind=load_judge_kind,
                     judge_status_cls=JudgeStatus,
                     trace_summary_cls=TraceChecksSummary,
                     trace_constraint_cls=TraceConstraintResult,
@@ -348,7 +348,7 @@ class CompositeGraderKind:
         logger: Any,
         composite_mod: Any,
         composite_components_cls: Any,
-        load_rubric_evaluator: Any,
+        load_judge_kind: Any,
         judge_status_cls: Any,
         trace_summary_cls: Any,
         trace_constraint_cls: Any,
@@ -360,7 +360,6 @@ class CompositeGraderKind:
         which we cannot import directly (importlinter contract
         ``grader-kinds-purity`` forbids reaching ``tolokaforge.grader``)."""
         from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
-        from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
         from tolokaforge.runner.models import TraceChecksResult
 
         components = composite_components_cls()
@@ -420,14 +419,7 @@ class CompositeGraderKind:
                 if customization and customization.include_agent_system_prompt is not None
                 else True
             )
-            rubric_evaluator = load_rubric_evaluator("llm_judge")(
-                RubricEvaluatorContext(
-                    judge_model_provider=judge_model_provider,
-                    disable_knowledge_search=disable_kb,
-                    custom_system_prompt=custom_prompt,
-                    include_agent_system_prompt=include_agent_prompt,
-                )
-            )
+            judge_kind = load_judge_kind("single_shot_rubric")()
             state_diff_text = composite_mod.build_judge_state_diff(
                 trial_id=trial_id,
                 substrate=substrate,
@@ -440,7 +432,12 @@ class CompositeGraderKind:
                 trial_id=trial_id,
                 config=task_config.llm_judge,
                 substrate=substrate,
-                rubric_evaluator=rubric_evaluator,
+                judge_kind=judge_kind,
+                judge_model_provider=judge_model_provider,
+                disable_knowledge_search=disable_kb,
+                custom_system_prompt=custom_prompt,
+                include_agent_system_prompt=include_agent_prompt,
+                kind_config=None,
                 llm_messages=llm_messages,
                 judge_model_config=judge_model_config,
                 extra_read_tools=[],

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -8,6 +8,7 @@ External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.actors.turn_policy.TurnPolicy`,
 :class:`~tolokaforge.core.grading.grading_method.GradingMethod`,
 :class:`~tolokaforge.core.grading.kinds.GraderKind`,
+:class:`~tolokaforge.core.grading.judge_kinds.JudgeKind`,
 :class:`~tolokaforge.core.grading.substrate.GradingSubstrate`,
 :class:`~tolokaforge.core.grading.check_runner.CheckExecutor`,
 :class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`,
@@ -53,6 +54,7 @@ The groups:
 * ``tolokaforge.turn_policies`` → :data:`TurnPolicyFactory`
 * ``tolokaforge.grading_methods`` → ``type[GradingMethod]``
 * ``tolokaforge.grader_kinds`` → ``type[GraderKind]``
+* ``tolokaforge.judge_kinds`` → ``type[JudgeKind]``
 * ``tolokaforge.bundle_stores`` → ``type[BundleStore]``
 * ``tolokaforge.compose_materialisers`` → ``type[ComposeMaterialiser]``
 * ``tolokaforge.service_lifecycle_dispatchers`` → ``type[ServiceLifecycleDispatcher]``
@@ -90,6 +92,7 @@ from typing import TYPE_CHECKING, cast
 
 from tolokaforge.core.grading.check_runner import CheckExecutor
 from tolokaforge.core.grading.grading_method import GradingMethod
+from tolokaforge.core.grading.judge_kinds import JudgeKind
 from tolokaforge.core.grading.judge_model_provider import JudgeModelProviderFactory
 from tolokaforge.core.grading.kinds import GraderKind
 from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorFactory
@@ -154,6 +157,7 @@ __all__ = [
     "available_grader_kinds",
     "available_grading_methods",
     "available_grading_substrates",
+    "available_judge_kinds",
     "available_judge_model_providers",
     "available_readiness_probes",
     "available_rubric_evaluators",
@@ -173,6 +177,7 @@ __all__ = [
     "load_grader_kind",
     "load_grading_method",
     "load_grading_substrate",
+    "load_judge_kind",
     "load_judge_model_provider",
     "load_readiness_probe",
     "load_rubric_evaluator",
@@ -193,6 +198,7 @@ SERVICE_READINESS_PROBES_GROUP = "tolokaforge.service_readiness_probes"
 TURN_POLICIES_GROUP = "tolokaforge.turn_policies"
 GRADING_METHODS_GROUP = "tolokaforge.grading_methods"
 GRADER_KINDS_GROUP = "tolokaforge.grader_kinds"
+JUDGE_KINDS_GROUP = "tolokaforge.judge_kinds"
 GRADING_SUBSTRATES_GROUP = "tolokaforge.grading_substrates"
 CUSTOM_CHECK_EXECUTORS_GROUP = "tolokaforge.custom_check_executors"
 JUDGE_MODEL_PROVIDERS_GROUP = "tolokaforge.judge_model_providers"
@@ -551,6 +557,22 @@ def load_grader_kind(name: str) -> type[GraderKind]:
     return cast(type[GraderKind], _load(GRADER_KINDS_GROUP, name))
 
 
+def load_judge_kind(name: str) -> type[JudgeKind]:
+    """Resolve a registered judge-kind name to its implementation class.
+
+    Returns the class object itself, matching :func:`load_grader_kind`.
+    The runner-side composite dispatch resolves this loader to reach the
+    LLM-judge implementation registered as ``single_shot_rubric`` (the
+    shipping reference impl wrapping :class:`LLMJudge`); downstream
+    packages register alternative kinds (chunked, agentic, jury,
+    downstream-specific) under this group.
+
+    Fail-loud on unknown names via :class:`UnknownImplementationError`,
+    matching every other loader in this module.
+    """
+    return cast(type[JudgeKind], _load(JUDGE_KINDS_GROUP, name))
+
+
 def load_bundle_store(name: str) -> type[BundleStore]:
     """Resolve a registered bundle-store name to its implementation class.
 
@@ -646,6 +668,11 @@ def available_grading_methods() -> list[str]:
 def available_grader_kinds() -> list[str]:
     """Sorted names registered in the ``tolokaforge.grader_kinds`` group."""
     return sorted(discover_entry_points(GRADER_KINDS_GROUP))
+
+
+def available_judge_kinds() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.judge_kinds`` group."""
+    return sorted(discover_entry_points(JUDGE_KINDS_GROUP))
 
 
 def available_grading_substrates() -> list[str]:

--- a/tolokaforge/grader/composite_dispatch.py
+++ b/tolokaforge/grader/composite_dispatch.py
@@ -505,10 +505,7 @@ class GraderCompositeDispatch:
             return None, JudgeStatus.UNSPECIFIED, False, {}
         if not llm_messages:
             return None, JudgeStatus.UNSPECIFIED, False, {LLM_JUDGE_KEY: NO_JUDGE_MESSAGES_SKIP}
-        judge_model_config_present = (
-            "llm_judge branch requires judge_model_config — validated above"
-        )
-        assert judge_model_config is not None, judge_model_config_present
+        assert judge_model_config is not None, "llm_judge branch requires judge_model_config"
         judge_kind = load_judge_kind("single_shot_rubric")()
         customization = llm_judge_config.customization
         disable_knowledge_search = bool(customization and customization.disable_knowledge_search)

--- a/tolokaforge/grader/composite_dispatch.py
+++ b/tolokaforge/grader/composite_dispatch.py
@@ -10,9 +10,9 @@ dialled at the runner's substrate address.
 boot. Five holistic seams (custom-check executor, judge-model provider,
 transcript-rule matcher, state-check backends, substrate class) are
 loaded from :mod:`tolokaforge.core.plugin_registry` and cached on the
-instance; the sixth seam — the rubric evaluator — is loaded per-``grade``
+instance; the sixth seam — the judge kind — is loaded per-``grade``
 call because :class:`~tolokaforge.runner.models.LLMJudgeConfig.customization`
-shapes its construction and rides on the wire per trial.
+shapes the per-``evaluate`` kwargs and rides on the wire per trial.
 
 Each :meth:`grade` call validates the required v2 wire fields, deserialises
 the run-scoped :class:`~tolokaforge.runner.models.RunnerGradingConfig` /
@@ -68,8 +68,8 @@ from tolokaforge.core.models import (
 from tolokaforge.core.plugin_registry import (
     load_custom_check_executor,
     load_grading_substrate,
+    load_judge_kind,
     load_judge_model_provider,
-    load_rubric_evaluator,
     load_state_check_backend,
     load_transcript_rule_matcher,
 )
@@ -91,7 +91,6 @@ from tolokaforge.runner.protocol import parse_termination_reason
 
 if TYPE_CHECKING:
     from tolokaforge.core.grading.judge_result import JudgeResult
-    from tolokaforge.core.grading.rubric_evaluator import RubricEvaluator
     from tolokaforge.core.grading.substrate import GradingSubstrate
     from tolokaforge.core.grading.transcript import TranscriptEvaluationResult
     from tolokaforge.core.logging import StructuredLogger
@@ -107,8 +106,9 @@ class GraderCompositeDispatch:
     seams over a :class:`LiveRunnerCallbackGradingSubstrate`.
 
     Constructed once per grader process. Five holistic seams cache at
-    construction; the rubric-evaluator seam loads per-call because the
-    trial's :class:`LLMJudgeConfig.customization` shapes its context.
+    construction; the judge-kind seam loads per-call because the trial's
+    :class:`LLMJudgeConfig.customization` shapes the per-``evaluate``
+    kwargs (KB gate, custom system-prompt, include-agent-system-prompt).
     Every :meth:`grade` call constructs a fresh substrate against the
     trial's ``runner_substrate_address``, extracts the pack's
     ``tool_artifacts`` bundle if present, runs the composite mirroring
@@ -489,7 +489,7 @@ class GraderCompositeDispatch:
         unstable_fields: set[tuple[str, str]],
         components: CompositeGradeComponents,
     ) -> tuple[JudgeResult | None, JudgeStatus, bool, dict[str, KeyAccountingRecord]]:
-        """Load the rubric-evaluator seam, render the state diff, and grade.
+        """Load the judge-kind seam, render the state diff, and grade.
 
         Returns ``(judge_result, wire_judge_status, judge_gate_failed, accounted_keys)``.
         A skipped judge (missing config or empty transcript) reports
@@ -505,10 +505,19 @@ class GraderCompositeDispatch:
             return None, JudgeStatus.UNSPECIFIED, False, {}
         if not llm_messages:
             return None, JudgeStatus.UNSPECIFIED, False, {LLM_JUDGE_KEY: NO_JUDGE_MESSAGES_SKIP}
-        assert (
-            judge_model_config is not None
-        ), "llm_judge branch requires judge_model_config — validated above"
-        rubric_evaluator = self._build_rubric_evaluator(llm_judge_config)
+        judge_model_config_present = (
+            "llm_judge branch requires judge_model_config — validated above"
+        )
+        assert judge_model_config is not None, judge_model_config_present
+        judge_kind = load_judge_kind("single_shot_rubric")()
+        customization = llm_judge_config.customization
+        disable_knowledge_search = bool(customization and customization.disable_knowledge_search)
+        custom_system_prompt = customization.system_prompt if customization else None
+        include_agent_system_prompt = (
+            customization.include_agent_system_prompt
+            if customization and customization.include_agent_system_prompt is not None
+            else True
+        )
         state_diff_text = composite.build_judge_state_diff(
             trial_id=trial_id,
             substrate=substrate,
@@ -521,7 +530,12 @@ class GraderCompositeDispatch:
             trial_id=trial_id,
             config=llm_judge_config,
             substrate=substrate,
-            rubric_evaluator=rubric_evaluator,
+            judge_kind=judge_kind,
+            judge_model_provider=self._judge_model_provider,
+            disable_knowledge_search=disable_knowledge_search,
+            custom_system_prompt=custom_system_prompt,
+            include_agent_system_prompt=include_agent_system_prompt,
+            kind_config=None,
             llm_messages=llm_messages,
             judge_model_config=judge_model_config,
             extra_read_tools=[],
@@ -535,32 +549,6 @@ class GraderCompositeDispatch:
         if judge_result.score is not None:
             components.llm_judge_score = judge_result.score
         return judge_result, JudgeStatus.COMPLETED, judge_gate_failed, accounted
-
-    def _build_rubric_evaluator(self, llm_judge_config: Any) -> RubricEvaluator:
-        """Load the ``llm_judge`` rubric-evaluator seam with per-trial context.
-
-        Mirrors the runner's ``_grade_llm_judge`` construction — the trial's
-        :attr:`LLMJudgeConfig.customization` shapes the KB gate, custom
-        system-prompt override, and the include-agent-system-prompt default.
-        """
-        from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
-
-        customization = llm_judge_config.customization
-        disable_knowledge_search = bool(customization and customization.disable_knowledge_search)
-        custom_system_prompt = customization.system_prompt if customization else None
-        include_agent_system_prompt = (
-            customization.include_agent_system_prompt
-            if customization and customization.include_agent_system_prompt is not None
-            else True
-        )
-        return load_rubric_evaluator("llm_judge")(
-            RubricEvaluatorContext(
-                judge_model_provider=self._judge_model_provider,
-                disable_knowledge_search=disable_knowledge_search,
-                custom_system_prompt=custom_system_prompt,
-                include_agent_system_prompt=include_agent_system_prompt,
-            )
-        )
 
 
 def _build_grade(

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -73,7 +73,6 @@ from tolokaforge.core.grading.trace_timeline import (
 )
 from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcher
 from tolokaforge.core.hash import apply_compare_columns_extras, compute_stable_hash
-from tolokaforge.core.logging import get_logger
 from tolokaforge.core.models import (
     CriterionResult,
     LLMJudgeConfig,
@@ -1387,10 +1386,10 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 else:
                     error_message = f"Tool '{tool_name}' not found. Did you mean: {hint}?"
                 logger.warning(
-                    "ExecuteTool: Tool not found",
-                    tool_name=tool_name,
-                    executor=executor.value,
-                    candidates=hint,
+                    "ExecuteTool: Tool not found: %s (%s). Candidates: %s",
+                    tool_name,
+                    executor.value,
+                    hint,
                 )
             else:
                 error_message = f"Tool '{tool_name}' not found"
@@ -1802,11 +1801,11 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             # Reward-cat is a diagnostic read; the fallback bytes match the shell
             # ``|| echo 0.0`` path so the kind renders the same "0.0" reward.
             logger.warning(
-                "RunnerServiceImpl._run_test_suite_via_agent_tools: reward-cat raised; "
-                "falling back to b'0.0\\n'",
-                trial_id=trial_id,
-                error=str(exc),
-                error_type=type(exc).__name__,
+                "RunnerServiceImpl._run_test_suite_via_agent_tools: reward-cat raised "
+                "for trial %r: %s: %s; falling back to b'0.0\\n'",
+                trial_id,
+                type(exc).__name__,
+                exc,
             )
             reward_bytes = b"0.0\n"
 
@@ -2414,7 +2413,9 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             else True
         )
         judge_kind = load_judge_kind("single_shot_rubric")()
-        judge_logger = get_logger("rubric_judge")
+        from tolokaforge.core import logging as _tolokaforge_logging
+
+        judge_logger = _tolokaforge_logging.get_logger("rubric_judge")
 
         def _run() -> "JudgeResult":
             state_diff_text = composite.build_judge_state_diff(

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -2361,21 +2361,22 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
     ) -> "JudgeResult":
         """Delegate to :func:`composite.grade_llm_judge` over the runner's substrate.
 
-        The composite owns the judge dispatch (rubric plumbing, forwarding to
-        the resolved :class:`RubricEvaluator`); this wrapper collects the
-        trial-context passthroughs (judge ``ModelConfig``, ``search_policy``
-        connector reuse), constructs the ``RubricEvaluator`` from the run-level
-        :attr:`_judge_model_provider` and per-trial customization flags,
-        renders the ``initial → final`` state diff for the evaluator's opening
-        message, and delegates. The ``InProcessGradingSubstrate`` built once
-        by :meth:`_build_grading_substrate` at the outer level is shared
-        here — the judge's read-only DB tools go through
-        ``substrate.db_reader()``, the same ``_LoopBridgeDBReader`` closure the
-        state-checks path uses.
+        Resolves ``load_judge_kind("single_shot_rubric")()`` and hands the kind
+        together with the run-level :attr:`_judge_model_provider` and the
+        per-trial customization kwargs (``disable_knowledge_search``,
+        ``custom_system_prompt``, ``include_agent_system_prompt``, plus
+        ``kind_config=None``) to :func:`composite.grade_llm_judge`. This wrapper
+        also collects the trial-context passthroughs (judge ``ModelConfig``,
+        ``search_policy`` connector reuse) and renders the
+        ``initial → final`` state diff for the judge's opening message. The
+        ``InProcessGradingSubstrate`` built once by
+        :meth:`_build_grading_substrate` at the outer level is shared here —
+        the *kind*'s read-only DB tools go through ``substrate.db_reader()``,
+        the same ``_LoopBridgeDBReader`` closure the state-checks path uses.
 
         Sync-in-async: :func:`composite.grade_llm_judge` is a sync function whose
-        substrate reads (and the evaluator's own DB tool calls) bridge back to
-        this loop via ``run_coroutine_threadsafe``; driving it on the loop thread
+        substrate reads (and the kind's own DB tool calls) bridge back to this
+        loop via ``run_coroutine_threadsafe``; driving it on the loop thread
         would deadlock at the first call. ``run_in_executor`` lands the work on
         a worker thread so the bridges resolve.
         """

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1387,10 +1387,10 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 else:
                     error_message = f"Tool '{tool_name}' not found. Did you mean: {hint}?"
                 logger.warning(
-                    "ExecuteTool: Tool not found: %s (%s). Candidates: %s",
-                    tool_name,
-                    executor.value,
-                    hint,
+                    "ExecuteTool: Tool not found",
+                    tool_name=tool_name,
+                    executor=executor.value,
+                    candidates=hint,
                 )
             else:
                 error_message = f"Tool '{tool_name}' not found"
@@ -1802,11 +1802,11 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             # Reward-cat is a diagnostic read; the fallback bytes match the shell
             # ``|| echo 0.0`` path so the kind renders the same "0.0" reward.
             logger.warning(
-                "RunnerServiceImpl._run_test_suite_via_agent_tools: reward-cat raised "
-                "for trial %r: %s: %s; falling back to b'0.0\\n'",
-                trial_id,
-                type(exc).__name__,
-                exc,
+                "RunnerServiceImpl._run_test_suite_via_agent_tools: reward-cat raised; "
+                "falling back to b'0.0\\n'",
+                trial_id=trial_id,
+                error=str(exc),
+                error_type=type(exc).__name__,
             )
             reward_bytes = b"0.0\n"
 

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -73,6 +73,7 @@ from tolokaforge.core.grading.trace_timeline import (
 )
 from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcher
 from tolokaforge.core.hash import apply_compare_columns_extras, compute_stable_hash
+from tolokaforge.core.logging import get_logger
 from tolokaforge.core.models import (
     CriterionResult,
     LLMJudgeConfig,
@@ -86,8 +87,8 @@ from tolokaforge.core.plugin_registry import (
     load_custom_check_executor,
     load_grader_kind,
     load_grading_method,
+    load_judge_kind,
     load_judge_model_provider,
-    load_rubric_evaluator,
     load_state_check_backend,
     load_transcript_rule_matcher,
 )
@@ -2379,7 +2380,6 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         a worker thread so the bridges resolve.
         """
         from tolokaforge.core.grading.composite import grade_llm_judge
-        from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
 
         # The judge model is a run-level config that rides the TrialSpec. The
         # orchestrator validates up front that it is present whenever any selected
@@ -2412,14 +2412,8 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             if customization and customization.include_agent_system_prompt is not None
             else True
         )
-        rubric_evaluator = load_rubric_evaluator("llm_judge")(
-            RubricEvaluatorContext(
-                judge_model_provider=self._judge_model_provider,
-                disable_knowledge_search=disable_knowledge_search,
-                custom_system_prompt=custom_system_prompt,
-                include_agent_system_prompt=include_agent_system_prompt,
-            )
-        )
+        judge_kind = load_judge_kind("single_shot_rubric")()
+        judge_logger = get_logger("rubric_judge")
 
         def _run() -> "JudgeResult":
             state_diff_text = composite.build_judge_state_diff(
@@ -2434,12 +2428,17 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 trial_id=trial_id,
                 config=llm_judge_config,
                 substrate=substrate,
-                rubric_evaluator=rubric_evaluator,
+                judge_kind=judge_kind,
+                judge_model_provider=self._judge_model_provider,
+                disable_knowledge_search=disable_knowledge_search,
+                custom_system_prompt=custom_system_prompt,
+                include_agent_system_prompt=include_agent_system_prompt,
+                kind_config=None,
                 llm_messages=llm_messages,
                 judge_model_config=judge_model_config,
                 extra_read_tools=extra_read_tools,
                 state_diff=state_diff_text,
-                logger=logger,  # type: ignore[arg-type]  # module logger, satisfies StructuredLogger protocol at runtime
+                logger=judge_logger,
             )
 
         return await self._loop.run_in_executor(None, _run)


### PR DESCRIPTION
## Summary

- Introduces `tolokaforge.judge_kinds` as the runner-side LLM-judge dispatch seam, mirroring `GraderKind`.
- One built-in ships: `single_shot_rubric` (`SingleShotRubricJudgeKind`) wraps today's `LLMJudge` invocation byte-identically.
- Four hardcoded `load_rubric_evaluator("llm_judge")` / direct-`LLMJudge` sites now route through `load_judge_kind("single_shot_rubric")`.

## Design choices

- **Registry mirrors `GraderKind`**: `NAME: ClassVar[str]` + kwargs-only `evaluate(...) -> JudgeResult`, `@runtime_checkable` — extension via entry-point, no framework PR to add a kind.
- **Deconstructed evidence kwargs on the seam** (`db_reader` / `kb_search` / `workspace_dir` / `extra_read_tools` / `state_diff`), not `substrate: GradingSubstrate` — mechanically preserves LLMJudge byte-parity; judge-only callers have no substrate to hand in.
- **`JudgeModelProvider` handed in by the caller** rather than built inside the kind — preserves the runner's one-provider-per-service resource shape and avoids per-trial `importlib.metadata` scans on the hot path.
- **`kind_config: Mapping[str, Any] | None` lands on the Protocol at A1** (unused today) so downstream kinds (chunked, agentic) do not gain a kwarg mid-workstream.
- **`logger: StructuredLogger` non-optional** to mirror `GraderKind` verbatim; runner rewire threads a real `StructuredLogger` via `get_logger("rubric_judge")` and drops a pre-existing `# type: ignore[arg-type]` lie about the stdlib module logger.
- **`tolokaforge.rubric_evaluators` intentionally left registered** — byte-parity test drives both paths side-by-side; retirement is deferred #1575 with three-part rationale.
- **`replay.py::replay_trial` deliberately left direct at A1** — bundle-native `explicit_system_prompt` XOR contract; closed by Phase B2 (#1569) when the bundle carries `judge_kind`.

## Concepts introduced

**`JudgeKind`** — a typed Protocol + entry-point registry for LLM-judge implementations. Every judge dispatch site resolves through `load_judge_kind(name)` from `tolokaforge.judge_kinds`; each concrete kind is a class-typed, arg-less-constructible implementation whose `evaluate(...)` takes deconstructed per-trial evidence + model provider + customization + a reserved `kind_config` handle. The pluggable surface downstream milestone work (`chunked_rubric` in Phase B, `agentic_rubric` in Phase C) plugs into without touching engine code.

## Plan

The full staged plan (Goal, Non-goals, Contract, Stage 1 details, Discovered issues, Risks, Approved decisions) lives at `~/.claude/plans/toloka-tolokaforge/issue-1566-judge-kind-protocol.md`. Key excerpt — Stage 1 (one commit):

- **Contract:** `JudgeKind` Protocol at `tolokaforge/core/grading/judge_kinds/_protocol.py`; entry-point block `[project.entry-points."tolokaforge.judge_kinds"]` with `single_shot_rubric`; `load_judge_kind` + `available_judge_kinds` on `plugin_registry.py`; runner-subset entry-point allowlist entries in `hatch_runner_subset_builder.py` + `test_runner_subset_partition.py`.
- **Six behaviour-locking canonical tests:** byte-parity between `LLMJudgeRubricEvaluator` and `SingleShotRubricJudgeKind` on the same scripted judge model; registry / resolver / unknown-name / Protocol-satisfaction invariants; third-party `importlib.metadata` registration; extended builtin-inventory checks; existing `test_judge_only_composite_llm_judge_only_parity` stays green untouched; live composite dispatch through the new seam.
- **Doc rewrites:** `docs/GRADER_SERVICE.md` (8 rubric_evaluator hits) + `docs/RUNNER.md` (1 hit) rewritten as if `judge_kinds` is the current seam. (Plan originally named `docs/GRADING.md` + `docs/LLM_LAYER.md` — both had zero rubric_evaluator mentions on `main`; justified drift recorded in plan.)
- **Compat:** internal only; `tolokaforge.rubric_evaluators` group stays registered.

**Approved decisions:** substrate-decomposed kwargs; provider handed in by caller; no `preferred_judge_kind()` on adapters at A1.

## Discovered issues

- **Filed as in-milestone follow-ups:** none.
- **Deferred (rationale required):** `#1575 [deferred:M49]` — `chore(grading): retire tolokaforge.rubric_evaluators once every consumer moves to tolokaforge.judge_kinds`. Rationale: retirement runs cleanly only after Phase B/C ships the κ gate + config field + two new kinds AND third-party consumers migrate; parallels `#1466` (unmilestoned rolling cleanup for the analogous `grading_methods` retirement).
- **Fixed in this PR:** none additional beyond the two inline reviewer-fix corrections (runner `StructuredLogger` threading, test signature update).
- **Routed to `#1546`:** 13 pre-existing canonical failures (`test_example_pack_grading_corpus` × 4, `test_grading_wire_lock` × 5, `test_native_adapter_canon` × 4) enumerated on the arena-v3 residuals umbrella comment so subsequent M49 PRs do not inherit the noise silently.

## Test plan

- `mcp__dev__run_tests marker=canonical paths="tests/canonical/test_judge_kinds_registry.py tests/canonical/test_judge_kind_single_shot_byte_parity.py tests/canonical/test_judge_kinds_third_party_registration.py tests/canonical/test_builtin_plugin_registrations.py tests/canonical/test_judge_only_composite_llm_judge_only_parity.py tests/canonical/test_grading_composite_llm_judge.py tests/canonical/test_grading_rubric_evaluator_dispatch.py tests/canonical/test_grader_kinds_registry.py tests/canonical/test_runner_subset_partition.py"` — 92 passed / 0 failed / 0 skipped.
- `mcp__dev__run_tests marker=unit` — whole lane exit-code 0.
- `mcp__dev__lint_check paths="tolokaforge tests scripts"` — clean.
- `rg 'load_rubric_evaluator\("llm_judge"\)' tolokaforge/` → 0 hits post-rewire.
- `test_subset_wheel_carries_runner_reachable_entry_point_groups` rebuilds the subset wheel and asserts `[tolokaforge.judge_kinds]` is carried through — locks the runner-subset allowlist gate.

Closes #1566