### PR TITLE
fix(packaging): bundle coding-harnesses into tolokaforge wheel (0.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+## v0.25.1 (2026-09-11)
+
+### Fix
+
+- **packaging**: bundle `tolokaforge_coding_harnesses` INTO the tolokaforge wheel and drop the runtime dep on the sibling PyPI distribution (which was never intended to publish). Fixes `pip install tolokaforge==0.25.0` failing with `No matching distribution found for tolokaforge-coding-harnesses`.
+- **docker**: include `tolokaforge_coding_harnesses/` in the runner + grader Dockerfile build context (both were tripping on `COPY failed: file not found in build context`).
+
 ## v0.25.0 (2026-09-11)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tolokaforge"
-version = "0.25.0"
+version = "0.25.1"
 description = "Tolokaforge - LLM Tool-Use Benchmarking Harness"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -38,9 +38,11 @@ dependencies = [
     "tolokaforge-models>=1.0.0,<2.0.0",
     # Coding-harness registry, spec models and adapter-support mixin (see
     # ADR-0039). Imported unconditionally by :mod:`tolokaforge.adapters.native`
-    # and :mod:`tolokaforge.adapters.native_harness_synthesis`, so a headless
-    # ``pip install tolokaforge`` needs the sibling wheel on ``sys.path`` too.
-    "tolokaforge-coding-harnesses>=0.1.0,<1.0.0",
+    # and :mod:`tolokaforge.adapters.native_harness_synthesis`. Bundled INTO
+    # the tolokaforge wheel (see ``[tool.hatch.build.targets.wheel]`` below)
+    # rather than published as a sibling on PyPI, so ``pip install tolokaforge``
+    # is self-contained. jinja2 below is coding_harnesses' template-render dep.
+    "jinja2>=3.1.0",
     # Core LLM integration
     "litellm>=1.83.14,!=1.92.0,<2.0.0",
     # Data validation and schemas
@@ -364,7 +366,19 @@ exclude = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["tolokaforge"]
+# ``tolokaforge_coding_harnesses`` is a workspace-sibling source tree
+# (see ``[tool.uv.workspace]`` further down) that we bundle INTO the
+# tolokaforge wheel rather than publishing as its own PyPI distribution.
+# Hatch reads each entry's basename as the installed package name, so this
+# bundles ``tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/``
+# as the top-level ``tolokaforge_coding_harnesses`` package on
+# ``site-packages``. Import paths inside ``tolokaforge.adapters.native`` and
+# friends resolve unchanged; ``pip install tolokaforge`` from PyPI is
+# self-contained.
+packages = [
+    "tolokaforge",
+    "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses",
+]
 
 # Ship `.python-version` inside the built wheel as
 # ``tolokaforge/_python_version.txt``. The repo-root dotfile is the
@@ -400,6 +414,11 @@ packages = ["tolokaforge"]
 # context entry to a packaged copy and `COPY tolokaforge_models/` fails.
 "tolokaforge_models/pyproject.toml" = "tolokaforge/_subset_build/tolokaforge_models/pyproject.toml"
 "tolokaforge_models/src" = "tolokaforge/_subset_build/tolokaforge_models/src"
+# Same pattern for the coding-harnesses sibling: the runner Dockerfile builds
+# its wheel in-container (like tolokaforge_models). ``_runner_definition()``
+# needs a packaged copy on a wheel install where the repo root is absent.
+"tolokaforge_coding_harnesses/pyproject.toml" = "tolokaforge/_subset_build/tolokaforge_coding_harnesses/pyproject.toml"
+"tolokaforge_coding_harnesses/src" = "tolokaforge/_subset_build/tolokaforge_coding_harnesses/src"
 
 [tool.hatch.build.targets.sdist]
 

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -297,6 +297,12 @@ def test_runner_build_context_ships_source_tree_for_multi_stage_hatch_build() ->
         # models wheel in-place from source (rather than pulling from
         # PyPI) so the runner image installs the branch's exact bytes.
         "tolokaforge_models/",
+        # tolokaforge_coding_harnesses ships INSIDE the base tolokaforge
+        # wheel on PyPI (see workspace pyproject `[tool.hatch.build.targets.wheel]`),
+        # never as its own PyPI distribution. The runner subset still gets
+        # a companion wheel built in-container, so the source tree ships
+        # in the build context alongside tolokaforge_models.
+        "tolokaforge_coding_harnesses/",
     }
     assert set(context_files) == expected, (
         "runner image context_files drifted from the ADR-0025 multi-stage "
@@ -610,6 +616,16 @@ def test_runner_build_context_resolves_from_installed_wheel(tmp_path: Path, monk
     # in-container `hatchling build` step (Milestone 29 / ADR-0030).
     (packaged / "tolokaforge_models" / "src" / "tolokaforge_models").mkdir(parents=True)
     (packaged / "tolokaforge_models" / "pyproject.toml").write_text("# models pyproject\n")
+    # Same shape for tolokaforge_coding_harnesses: bundled INSIDE the base
+    # wheel on PyPI, with a packaged copy of its source at
+    # ``tolokaforge/_subset_build/tolokaforge_coding_harnesses/`` so the
+    # runner Dockerfile's in-container hatchling build step still has it.
+    (packaged / "tolokaforge_coding_harnesses" / "src" / "tolokaforge_coding_harnesses").mkdir(
+        parents=True
+    )
+    (packaged / "tolokaforge_coding_harnesses" / "pyproject.toml").write_text(
+        "# coding-harnesses pyproject\n"
+    )
     (pkg / "_python_version.txt").write_text("3.12\n")
     # The base wheel ships the Dockerfiles inside the package, so
     # ``assemble_build_context`` still finds the runner Dockerfile under
@@ -640,6 +656,8 @@ def test_runner_build_context_resolves_from_installed_wheel(tmp_path: Path, monk
             "tolokaforge",
             "tolokaforge_models/pyproject.toml",
             "tolokaforge_models/src/tolokaforge_models",
+            "tolokaforge_coding_harnesses/pyproject.toml",
+            "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses",
         ):
             assert (build_dir / expected).exists(), (
                 f"assembled runner context is missing '{expected}', which the "
@@ -714,6 +732,14 @@ def test_core_stack_runner_context_assembles_on_a_wheel_install(
     # in-container `hatchling build` step (Milestone 29 / ADR-0030).
     (packaged / "tolokaforge_models" / "src" / "tolokaforge_models").mkdir(parents=True)
     (packaged / "tolokaforge_models" / "pyproject.toml").write_text("# models pyproject\n")
+    # Same shape for tolokaforge_coding_harnesses (bundled INSIDE the base
+    # wheel on PyPI; source copy under _subset_build for in-container hatch).
+    (packaged / "tolokaforge_coding_harnesses" / "src" / "tolokaforge_coding_harnesses").mkdir(
+        parents=True
+    )
+    (packaged / "tolokaforge_coding_harnesses" / "pyproject.toml").write_text(
+        "# coding-harnesses pyproject\n"
+    )
     (pkg / "_python_version.txt").write_text("3.12\n")
     dockerfiles = pkg / "docker" / "dockerfiles"
     dockerfiles.mkdir(parents=True)
@@ -733,6 +759,8 @@ def test_core_stack_runner_context_assembles_on_a_wheel_install(
             "tolokaforge",
             "tolokaforge_models/pyproject.toml",
             "tolokaforge_models/src/tolokaforge_models",
+            "tolokaforge_coding_harnesses/pyproject.toml",
+            "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses",
         ):
             assert (build_dir / expected).exists(), (
                 f"core_stack()'s runner context is missing '{expected}' on a wheel "

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -116,6 +116,13 @@ _RUNNER_SOURCE_CONTEXT_FILES: list[str] = [
     # bit-for-bit source of truth (docker installs the freshly-built wheel
     # from the checked-out tree, not whatever PyPI currently ships).
     "tolokaforge_models/",
+    # ``tolokaforge_coding_harnesses`` follows the same in-container-build
+    # pattern but never publishes to PyPI: the base wheel bundles it directly
+    # (see ``[tool.hatch.build.targets.wheel]`` in the workspace pyproject).
+    # The runner subset wheel still needs the source tree in its build
+    # context so the wheel-builder stage can produce a companion wheel
+    # installed alongside the subset wheel.
+    "tolokaforge_coding_harnesses/",
 ]
 
 #: Where the base wheel's ``force-include`` table lands the repo-root files
@@ -313,6 +320,10 @@ def _runner_definition() -> dict[str, Any]:
         # `COPY tolokaforge_models/ /src/tolokaforge_models/`, so a plain
         # absolute-path entry lands the directory under the right name.
         packaged / "tolokaforge_models",
+        # Same shape for tolokaforge_coding_harnesses — force-included by the
+        # base wheel and landed here so the Dockerfile's `COPY
+        # tolokaforge_coding_harnesses/` succeeds on a wheel install too.
+        packaged / "tolokaforge_coding_harnesses",
     ]
     missing = [
         str(e[0] if isinstance(e, tuple) else e)

--- a/tolokaforge/docker/dockerfiles/runner.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/runner.Dockerfile
@@ -55,6 +55,12 @@ COPY tolokaforge/ /src/tolokaforge/
 # the freshly-built wheel from the checked-out tree, not whatever PyPI
 # currently ships).
 COPY tolokaforge_models/ /src/tolokaforge_models/
+# tolokaforge_coding_harnesses is a workspace sibling that ships INSIDE the
+# base tolokaforge wheel on PyPI (see ``[tool.hatch.build.targets.wheel]``
+# in the workspace pyproject) — never as its own PyPI distribution. The
+# runner subset wheel uses a separate companion wheel built here in-container,
+# so the source tree ships in this build context alongside tolokaforge_models.
+COPY tolokaforge_coding_harnesses/ /src/tolokaforge_coding_harnesses/
 
 # Build the subset wheel. Output lands in ``/src/dist/`` as
 # ``tolokaforge_runner_subset-<version>-py3-none-any.whl``.
@@ -64,6 +70,11 @@ RUN python -m hatchling build --target custom
 # ``/src/tolokaforge_models/dist/`` as
 # ``tolokaforge_models-<version>-py3-none-any.whl``.
 RUN cd /src/tolokaforge_models && python -m hatchling build
+
+# Same for the coding-harnesses wheel. Output under
+# ``/src/tolokaforge_coding_harnesses/dist/`` as
+# ``tolokaforge_coding_harnesses-<version>-py3-none-any.whl``.
+RUN cd /src/tolokaforge_coding_harnesses && python -m hatchling build
 
 # ---------------------------------------------------------------------------
 # builder — install the subset wheel into /opt/venv
@@ -81,19 +92,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=wheel-builder /src/dist/tolokaforge_runner_subset-*.whl /tmp/
 COPY --from=wheel-builder /src/tolokaforge_models/dist/tolokaforge_models-*.whl /tmp/
+COPY --from=wheel-builder /src/tolokaforge_coding_harnesses/dist/tolokaforge_coding_harnesses-*.whl /tmp/
 
 # Install into an isolated venv. The subset wheel's METADATA carries every
 # runtime dep (the base wheel deps the runner reaches + the former
 # ``[runner]`` extra) plus ``tolokaforge-models>=1.0.0,<2.0.0``; the
 # freshly-built models wheel from the wheel-builder stage satisfies that pin
-# without touching PyPI. --no-compile keeps *.pyc bytecode out of
-# site-packages; PYTHONDONTWRITEBYTECODE in the runtime stage keeps it that
-# way.
+# without touching PyPI. tolokaforge-coding-harnesses is installed alongside
+# from its own freshly-built wheel because the runner subset imports
+# ``tolokaforge_coding_harnesses`` at boot and it never ships on PyPI (bundled
+# INTO the base tolokaforge wheel for PyPI users). --no-compile keeps *.pyc
+# bytecode out of site-packages; PYTHONDONTWRITEBYTECODE in the runtime stage
+# keeps it that way.
 RUN python -m venv /opt/venv \
     && /opt/venv/bin/pip install --no-cache-dir --no-compile \
         /tmp/tolokaforge_models-*.whl \
+        /tmp/tolokaforge_coding_harnesses-*.whl \
         /tmp/tolokaforge_runner_subset-*.whl \
-    && rm -f /tmp/tolokaforge_runner_subset-*.whl /tmp/tolokaforge_models-*.whl
+    && rm -f /tmp/tolokaforge_runner_subset-*.whl \
+              /tmp/tolokaforge_models-*.whl \
+              /tmp/tolokaforge_coding_harnesses-*.whl
 
 # ---------------------------------------------------------------------------
 # runtime — copy only the venv; no build toolchain

--- a/uv.lock
+++ b/uv.lock
@@ -4817,7 +4817,7 @@ wheels = [
 
 [[package]]
 name = "tolokaforge"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },
@@ -4843,7 +4843,6 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
     { name = "testcontainers" },
-    { name = "tolokaforge-coding-harnesses" },
     { name = "tolokaforge-models" },
     { name = "toml" },
     { name = "typesense" },
@@ -4995,7 +4994,6 @@ requires-dist = [
     { name = "tolokaforge", extras = ["dx", "browser", "server", "rag", "office", "adapters", "runner"], marker = "extra == 'all'", editable = "." },
     { name = "tolokaforge", extras = ["terminal-bench"], marker = "extra == 'adapters'", editable = "." },
     { name = "tolokaforge-adapter-terminal-bench", marker = "extra == 'terminal-bench'", editable = "external_adapters/tolokaforge-adapter-terminal-bench" },
-    { name = "tolokaforge-coding-harnesses", editable = "tolokaforge_coding_harnesses" },
     { name = "tolokaforge-models", editable = "tolokaforge_models" },
     { name = "toml", specifier = ">=0.10.0" },
     { name = "typesense", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

- The 0.25.0 wheel on PyPI is uninstallable: it declares a runtime dep on `tolokaforge-coding-harnesses>=0.1.0,<1.0.0`, but that sibling is not published to PyPI (per policy) — every `pip install tolokaforge` fails with `No matching distribution found`.
- The runner + grader Docker builds also fail at `COPY tolokaforge_coding_harnesses/` (build-context list missed the sibling source tree; caught by the post-release `test-full` lane).
- This PR bundles `tolokaforge_coding_harnesses` INTO the `tolokaforge` wheel and adds the source dir to the Docker build context.

## Changes

- **`pyproject.toml`** — drop coding-harnesses runtime dep; add `jinja2>=3.1.0` (its template dep); bundle `tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses` in `[tool.hatch.build.targets.wheel]` packages; force-include its source under `tolokaforge/_subset_build/`; bump version to `0.25.1`.
- **`tolokaforge/docker/builder.py`** — add `tolokaforge_coding_harnesses/` to `_RUNNER_SOURCE_CONTEXT_FILES` (feeds runner + grader) and add the packaged copy to `_runner_definition()`.
- **`tolokaforge/docker/dockerfiles/runner.Dockerfile`** — COPY the source tree, build its wheel inline (mirrors the `tolokaforge_models` pattern), install alongside the subset wheel.
- **`CHANGELOG.md`** — 0.25.1 entry.

## Test plan

- [x] Verified locally: built wheel bundles 25 `tolokaforge_coding_harnesses/*` entries + 13 `tolokaforge/_subset_build/tolokaforge_coding_harnesses/*` entries.
- [x] Verified locally: wheel's `METADATA` no longer lists `tolokaforge-coding-harnesses` as `Requires-Dist`; `jinja2` and `tolokaforge-models` still listed.
- [ ] CI (test-smoke + hygiene + lint) green on this branch.
- [ ] After merge: `Release (cz bump)` cuts 0.25.1, wheel installs cleanly from PyPI, `test-full` on `main` reaches the actual integration tests (was blocked at Docker build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)